### PR TITLE
feat: add slot helpers and nurse tile

### DIFF
--- a/src/slots.ts
+++ b/src/slots.ts
@@ -1,0 +1,101 @@
+
+export type Slot = {
+  nurseId: string;
+  student?: string | boolean;
+  comment?: string;
+  break?: {
+    active: boolean;
+    startISO?: string;
+    plannedEndHHMM?: string;
+    relievedBy?: { id?: string; rf?: string; name?: string };
+  };
+  endTimeOverrideHHMM?: string;
+  dto?: boolean;
+};
+
+export interface Board {
+  charge?: Slot;
+  triage?: Slot;
+  zones: Record<string, Slot[]>;
+}
+
+type SlotTarget = "charge" | "triage" | { zone: string; index?: number };
+
+export function ensureUniqueAssignment(board: Board, nurseId: string): void {
+  if (board.charge?.nurseId === nurseId) board.charge = undefined;
+  if (board.triage?.nurseId === nurseId) board.triage = undefined;
+  for (const zone of Object.keys(board.zones)) {
+    board.zones[zone] = board.zones[zone].filter((s) => s.nurseId !== nurseId);
+  }
+}
+
+export function upsertSlot(board: Board, target: SlotTarget, slot: Slot): void {
+  ensureUniqueAssignment(board, slot.nurseId);
+  if (target === "charge") {
+    board.charge = slot;
+  } else if (target === "triage") {
+    board.triage = slot;
+  } else {
+    const arr = board.zones[target.zone] || (board.zones[target.zone] = []);
+    if (target.index === undefined || target.index >= arr.length) {
+      arr.push(slot);
+    } else {
+      arr.splice(target.index, 0, slot);
+    }
+  }
+}
+
+export function removeSlot(
+  board: Board,
+  target: "charge" | "triage" | { zone: string; index: number }
+): void {
+  if (target === "charge") board.charge = undefined;
+  else if (target === "triage") board.triage = undefined;
+  else {
+    const arr = board.zones[target.zone];
+    if (arr) arr.splice(target.index, 1);
+  }
+}
+
+export function moveSlot(
+  board: Board,
+  from: "charge" | "triage" | { zone: string; index: number },
+  to: SlotTarget
+): void {
+  let slot: Slot | undefined;
+  if (from === "charge") {
+    slot = board.charge;
+    board.charge = undefined;
+  } else if (from === "triage") {
+    slot = board.triage;
+    board.triage = undefined;
+  } else {
+    slot = board.zones[from.zone]?.splice(from.index, 1)[0];
+  }
+  if (slot) upsertSlot(board, to, slot);
+}
+
+export function startBreak(
+  slot: Slot,
+  relievedBy: { id?: string; rf?: string; name?: string },
+  plannedEndHHMM?: string,
+  nowISO: string = new Date().toISOString()
+): void {
+  slot.break = {
+    active: true,
+    startISO: nowISO,
+    plannedEndHHMM,
+    relievedBy,
+  };
+}
+
+export function endBreak(slot: Slot): void {
+  if (slot.break) slot.break.active = false;
+}
+
+export function coveringDisplay(slot: Slot): string | undefined {
+  if (!slot.break?.active) return undefined;
+  const rb = slot.break.relievedBy;
+  return rb?.rf || rb?.id || rb?.name;
+}
+

--- a/src/state.ts
+++ b/src/state.ts
@@ -16,16 +16,15 @@ export type Staff = {
   class: "jewish" | "travel" | "float" | "other";
 };
 
-export interface RoleSlot {
-  nurseId: string;
-}
+import type { Slot } from "./slots";
+export type { Slot } from "./slots";
 
 export interface ActiveShift {
   dateISO: string;
   shift: Shift;
-  charge?: RoleSlot;
-  triage?: RoleSlot;
-  zones: Record<string, RoleSlot[]>;
+  charge?: Slot;
+  triage?: Slot;
+  zones: Record<string, Slot[]>;
   incoming: { nurseId: string; eta: string; arrived?: boolean }[];
   offgoing: { nurseId: string; ts: number }[];
   support: { techs: string[]; vols: string[]; sitters: string[] };

--- a/src/ui/nurseTile.ts
+++ b/src/ui/nurseTile.ts
@@ -1,0 +1,26 @@
+import type { Slot } from "../slots";
+import type { Staff } from "../state";
+import { coveringDisplay } from "../slots";
+
+export function nurseTile(slot: Slot, staff: Staff): string {
+  const chips: string[] = [];
+  if (slot.student) chips.push(`<span class="chip">S</span>`);
+  if (slot.comment)
+    chips.push(
+      `<span class="chip comment" title="${slot.comment}">💬</span>`
+    );
+  if (slot.break?.active) {
+    const cov = coveringDisplay(slot);
+    chips.push(
+      `<span class="chip break">Break${cov ? ` • Cov: ${cov}` : ""}</span>`
+    );
+  }
+  if (slot.dto) chips.push(`<span class="chip dto">DTO</span>`);
+  if (slot.endTimeOverrideHHMM)
+    chips.push(
+      `<span class="chip off-at">Off at ${slot.endTimeOverrideHHMM}</span>`
+    );
+  const chipStr = chips.length ? ` ${chips.join(" ")}` : "";
+  return `<div class="nurse-tile">${staff.name}${chipStr}</div>`;
+}
+

--- a/src/utils/staff.ts
+++ b/src/utils/staff.ts
@@ -1,0 +1,10 @@
+import type { Staff } from "../state";
+
+export function isEmployeeIdUnique(
+  staff: Staff[],
+  id: string,
+  existingId?: string
+): boolean {
+  return !staff.some((s) => s.id === id && s.id !== existingId);
+}
+

--- a/tests/slots.spec.ts
+++ b/tests/slots.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import {
+  ensureUniqueAssignment,
+  startBreak,
+  endBreak,
+  type Slot,
+  type Board,
+} from "../src/slots";
+import { isEmployeeIdUnique } from "../src/utils/staff";
+import { nurseTile as renderTile } from "../src/ui/nurseTile";
+
+describe("ensureUniqueAssignment", () => {
+  it("removes duplicates across board", () => {
+    const board: Board = {
+      charge: { nurseId: "1" },
+      triage: { nurseId: "2" },
+      zones: { A: [{ nurseId: "1" }, { nurseId: "3" }], B: [{ nurseId: "2" }] },
+    };
+    ensureUniqueAssignment(board, "1");
+    expect(board.charge).toBeUndefined();
+    expect(board.zones.A).toEqual([{ nurseId: "3" }]);
+    ensureUniqueAssignment(board, "2");
+    expect(board.triage).toBeUndefined();
+    expect(board.zones.B).toEqual([]);
+  });
+});
+
+describe("break toggles", () => {
+  it("starts and ends break with covering display", () => {
+    const slot: Slot = { nurseId: "1" };
+    startBreak(slot, { rf: "55221712" }, "12:00", "2024-01-01T00:00:00.000Z");
+    expect(slot.break?.active).toBe(true);
+    const html = renderTile(slot, {
+      id: "1",
+      name: "Alice",
+      class: "other",
+    });
+    expect(html).toContain("Cov: 55221712");
+    endBreak(slot);
+    expect(slot.break?.active).toBe(false);
+  });
+});
+
+describe("employee ID uniqueness", () => {
+  it("detects conflicts", () => {
+    const staff = [
+      { id: "1", name: "A", class: "other" },
+      { id: "2", name: "B", class: "other" },
+    ];
+    expect(isEmployeeIdUnique(staff, "3")).toBe(true);
+    expect(isEmployeeIdUnique(staff, "2")).toBe(false);
+    expect(isEmployeeIdUnique(staff, "2", "2")).toBe(true);
+  });
+});
+
+describe("nurse tile snapshot", () => {
+  it("renders chips", () => {
+    const slot: Slot = {
+      nurseId: "1",
+      student: "S1",
+      comment: "note",
+      break: {
+        active: true,
+        startISO: "2024-01-01T00:00:00.000Z",
+        plannedEndHHMM: "12:30",
+        relievedBy: { rf: "552" },
+      },
+      endTimeOverrideHHMM: "13:00",
+      dto: true,
+    };
+    const html = renderTile(slot, {
+      id: "1",
+      name: "Alice",
+      class: "other",
+    });
+    expect(html).toMatchInlineSnapshot(
+      `"<div class=\"nurse-tile\">Alice <span class=\"chip\">S</span> <span class=\"chip comment\" title=\"note\">💬</span> <span class=\"chip break\">Break • Cov: 552</span> <span class=\"chip dto\">DTO</span> <span class=\"chip off-at\">Off at 13:00</span></div>"`
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend nurse slot data to support student, comments, breaks, DTO, and end time
- add slot management helpers including unique-assignment enforcement and break handling
- render nurse tiles with chips for student, comments, break coverage, DTO, and off-at time
- provide employee ID uniqueness utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a284dda2448327811aad43edfdbb65