### PR TITLE
feat: add ops widgets

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { hhmmNowLocal, deriveShift } from '@/utils/time';
 import { renderHeader } from '@/ui/header';
 import { renderTabs, activeTab } from '@/ui/tabs';
 import { renderMain } from '@/ui/mainTab';
+import { renderSettingsTab } from '@/ui/settingsTab';
 
 export async function renderAll() {
   await renderHeader();
@@ -14,6 +15,9 @@ export async function renderAll() {
   switch (activeTab()) {
     case 'Main':
       await renderMain(root, { dateISO, shift });
+      break;
+    case 'Settings':
+      renderSettingsTab(root);
       break;
     // other tabs can be added here
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,6 +11,17 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
 header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-items:center;margin-bottom:var(--gap)}
 .title{font-size:var(--f-xl);font-weight:800;letter-spacing:.2px}
 .subtitle{color:var(--muted);font-size:var(--f)}
+.widgets{display:flex;flex-direction:column;gap:8px}
+.widget-card{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);padding:8px;font-size:var(--f)}
+.widget-card .temp{font-size:var(--f-lg);margin-left:4px}
+.widget-card .updated{color:var(--muted);font-size:.8em}
+.widget-card svg{width:24px;height:24px;margin-right:4px}
+.widget-menu{float:right}
+.widget-menu summary{list-style:none;cursor:pointer}
+.widget-menu div{display:flex;flex-direction:column;background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);position:absolute;margin-top:4px}
+.widget-menu button{background:none;color:var(--text);border:0;padding:4px 8px;text-align:left}
+.widgets,.widget-card{print-color-adjust:exact}
 @media print {
   body{background:white;color:black}
+  #widgets{display:none!important}
 }

--- a/src/ui/mainTab.ts
+++ b/src/ui/mainTab.ts
@@ -1,4 +1,5 @@
 import { DB, KS, getConfig } from '@/state';
+import { renderWidgets } from './widgets';
 
 function buildEmptyActive(dateISO: string, shift: 'day' | 'night') {
   const cfg = getConfig();
@@ -26,6 +27,10 @@ export async function renderMain(
   for (const z of cfg.zones || []) if (!active.zones[z]) active.zones[z] = [];
   try {
     root.innerHTML = `<pre>${JSON.stringify(active, null, 2)}</pre>`;
+    const widgets = document.createElement('div');
+    widgets.id = 'widgets';
+    root.appendChild(widgets);
+    await renderWidgets(widgets);
   } catch (err) {
     console.error(err);
     root.innerHTML = '<p class="error">Failed to render</p>';

--- a/src/ui/settingsTab.ts
+++ b/src/ui/settingsTab.ts
@@ -1,3 +1,111 @@
+import { getConfig, saveConfig, mergeConfigDefaults } from '@/state';
+import { fetchWeather, renderWidgets } from './widgets';
+
+function mapIcon(cond: string) {
+  const c = cond.toLowerCase();
+  if (c.includes('storm') || c.includes('thunder')) return 'storm';
+  if (c.includes('snow')) return 'snow';
+  if (c.includes('rain') || c.includes('drizzle')) return 'rain';
+  if (c.includes('cloud')) return 'cloud';
+  if (c.includes('mist') || c.includes('fog') || c.includes('haze')) return 'mist';
+  return 'sun';
+}
+
 export function renderSettingsTab(root: HTMLElement) {
-  root.innerHTML = "<p>Settings tab</p>";
+  const cfg = getConfig();
+  mergeConfigDefaults();
+  const w = cfg.widgets;
+  root.innerHTML = `
+    <section>
+      <h2>Widgets</h2>
+      <label><input type="checkbox" id="widgets-show" ${w.show !== false ? 'checked' : ''}/> Show widgets</label>
+      <h3>Weather</h3>
+      <label>Mode <select id="weather-mode"><option value="manual">Manual</option><option value="openweather">OpenWeather</option></select></label>
+      <label>Units <select id="weather-units"><option value="F">F</option><option value="C">C</option></select></label>
+      <label>City <input type="text" id="weather-city" value="${w.weather.city || ''}"></label>
+      <label>Lat <input type="number" id="weather-lat" value="${w.weather.lat ?? ''}"></label>
+      <label>Lon <input type="number" id="weather-lon" value="${w.weather.lon ?? ''}"></label>
+      <label>API Key <input type="password" id="weather-api" value="${w.weather.apiKey || ''}"></label>
+      <div id="weather-current" class="muted"></div>
+      <button id="save-weather">Save Weather</button>
+      <button id="fetch-weather">Fetch Now</button>
+      <div id="manual-fields" style="margin-top:8px;display:${w.weather.mode === 'manual' ? 'block' : 'none'}">
+        <label>Temperature <input type="number" id="manual-temp" value="${w.weather.current?.temp ?? ''}"></label>
+        <label>Condition <input type="text" id="manual-cond" value="${w.weather.current?.condition ?? ''}"></label>
+        <label>Location <input type="text" id="manual-loc" value="${w.weather.current?.location ?? ''}"></label>
+      </div>
+      <h3>Headlines</h3>
+      <label>Internal <input type="text" id="headline-int" value="${w.headlines.internal}"></label>
+      <label>External <input type="text" id="headline-ext" value="${w.headlines.external}"></label>
+      <button id="save-headlines">Save Headlines</button>
+    </section>`;
+
+  (document.getElementById('weather-mode') as HTMLSelectElement).value = w.weather.mode;
+  (document.getElementById('weather-units') as HTMLSelectElement).value = w.weather.units;
+  const currentEl = document.getElementById('weather-current')!;
+  if (w.weather.current) {
+    const cur = w.weather.current;
+    currentEl.textContent = `${Math.round(cur.temp)}° ${w.weather.units} ${cur.condition} ${cur.location || ''}`;
+  } else currentEl.textContent = '';
+
+  (document.getElementById('weather-mode') as HTMLSelectElement).addEventListener('change', (e) => {
+    const mode = (e.target as HTMLSelectElement).value;
+    document.getElementById('manual-fields')!.style.display = mode === 'manual' ? 'block' : 'none';
+  });
+
+  document.getElementById('save-weather')!.addEventListener('click', async () => {
+    const cfg = getConfig();
+    const w = cfg.widgets;
+    w.show = (document.getElementById('widgets-show') as HTMLInputElement).checked;
+    const mode = (document.getElementById('weather-mode') as HTMLSelectElement).value as 'manual' | 'openweather';
+    const newUnits = (document.getElementById('weather-units') as HTMLSelectElement).value as 'F' | 'C';
+    const prevUnits = w.weather.units;
+    w.weather.mode = mode;
+    w.weather.units = newUnits;
+    w.weather.city = (document.getElementById('weather-city') as HTMLInputElement).value || undefined;
+    const lat = parseFloat((document.getElementById('weather-lat') as HTMLInputElement).value);
+    w.weather.lat = isNaN(lat) ? undefined : lat;
+    const lon = parseFloat((document.getElementById('weather-lon') as HTMLInputElement).value);
+    w.weather.lon = isNaN(lon) ? undefined : lon;
+    w.weather.apiKey = (document.getElementById('weather-api') as HTMLInputElement).value || undefined;
+    if (mode === 'manual') {
+      const temp = parseFloat((document.getElementById('manual-temp') as HTMLInputElement).value);
+      const cond = (document.getElementById('manual-cond') as HTMLInputElement).value;
+      const loc = (document.getElementById('manual-loc') as HTMLInputElement).value;
+      w.weather.current = {
+        temp: temp,
+        condition: cond,
+        location: loc,
+        icon: mapIcon(cond),
+        updatedISO: new Date().toISOString(),
+      };
+    } else if (w.weather.current && prevUnits !== newUnits) {
+      // convert temp on unit change
+      w.weather.current.temp =
+        newUnits === 'C'
+          ? ((w.weather.current.temp - 32) * 5) / 9
+          : w.weather.current.temp * 9 / 5 + 32;
+    }
+    await saveConfig({ widgets: w });
+    const container = document.getElementById('widgets');
+    if (container) await renderWidgets(container);
+    renderSettingsTab(root);
+  });
+
+  document.getElementById('fetch-weather')!.addEventListener('click', async () => {
+    await fetchWeather();
+    const container = document.getElementById('widgets');
+    if (container) await renderWidgets(container);
+    renderSettingsTab(root);
+  });
+
+  document.getElementById('save-headlines')!.addEventListener('click', async () => {
+    const cfg = getConfig();
+    cfg.widgets.headlines.internal = (document.getElementById('headline-int') as HTMLInputElement).value;
+    cfg.widgets.headlines.external = (document.getElementById('headline-ext') as HTMLInputElement).value;
+    await saveConfig({ widgets: cfg.widgets });
+    const container = document.getElementById('widgets');
+    if (container) await renderWidgets(container);
+    renderSettingsTab(root);
+  });
 }

--- a/src/ui/widgets.ts
+++ b/src/ui/widgets.ts
@@ -1,0 +1,167 @@
+import { getConfig, saveConfig, mergeConfigDefaults } from '@/state';
+
+function svgIcon(paths: string) {
+  return `<svg class="icon" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${paths}</svg>`;
+}
+
+function iconSun() { return svgIcon('<circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>'); }
+function iconCloud() { return svgIcon('<path d="M4 15a4 4 0 0 1 2-7 5 5 0 0 1 9 3h1a3 3 0 0 1 0 6H6a4 4 0 0 1-2-2"/>'); }
+function iconRain() { return svgIcon('<path d="M4 15a4 4 0 0 1 2-7 5 5 0 0 1 9 3h1a3 3 0 0 1 0 6H6a4 4 0 0 1-2-2"/><path d="M8 20v2M12 20v2M16 20v2"/>'); }
+function iconStorm() { return svgIcon('<path d="M13 11h3l-4 7v-4h-3l4-7z"/><path d="M4 15a4 4 0 0 1 2-7 5 5 0 0 1 9 3h1a3 3 0 0 1 0 6H6a4 4 0 0 1-2-2"/>'); }
+function iconSnow() { return svgIcon('<path d="M4 15a4 4 0 0 1 2-7 5 5 0 0 1 9 3h1a3 3 0 0 1 0 6H6a4 4 0 0 1-2-2"/><path d="M8 19v2M12 19v2M16 19v2"/><path d="M8 21h8"/>'); }
+function iconMist() { return svgIcon('<path d="M3 15h18M3 12h18M5 9h14"/>'); }
+function iconMegaphone() { return svgIcon('<path d="M3 11v2a1 1 0 0 0 1 1h3l4 4v-14l-4 4H4a1 1 0 0 0-1 1z"/>'); }
+function iconCone() { return svgIcon('<path d="M12 2 3 22h18L12 2z"/><path d="M9 16h6"/>'); }
+
+const ICONS: Record<string, () => string> = {
+  sun: iconSun,
+  cloud: iconCloud,
+  rain: iconRain,
+  storm: iconStorm,
+  snow: iconSnow,
+  mist: iconMist,
+};
+
+function mapCondition(cond: string | undefined) {
+  if (!cond) return 'sun';
+  const c = cond.toLowerCase();
+  if (c.includes('storm') || c.includes('thunder')) return 'storm';
+  if (c.includes('snow')) return 'snow';
+  if (c.includes('rain') || c.includes('drizzle')) return 'rain';
+  if (c.includes('cloud')) return 'cloud';
+  if (c.includes('mist') || c.includes('fog') || c.includes('haze')) return 'mist';
+  return 'sun';
+}
+
+export async function fetchWeather(): Promise<void> {
+  const cfg = getConfig();
+  const w = cfg.widgets.weather;
+  if (w.mode !== 'openweather' || !w.apiKey) {
+    alert('Weather is set to Manual');
+    return;
+  }
+  const params = new URLSearchParams({ appid: w.apiKey, units: w.units === 'F' ? 'imperial' : 'metric' });
+  if (w.lat != null && w.lon != null) {
+    params.set('lat', String(w.lat));
+    params.set('lon', String(w.lon));
+  } else if (w.city) params.set('q', w.city);
+  else {
+    alert('Weather location not configured');
+    return;
+  }
+  try {
+    const res = await fetch(`https://api.openweathermap.org/data/2.5/weather?${params.toString()}`);
+    if (!res.ok) throw new Error('bad');
+    const data = await res.json();
+    w.current = {
+      temp: data.main?.temp,
+      condition: data.weather?.[0]?.main || '',
+      icon: mapCondition(data.weather?.[0]?.main),
+      location: data.name,
+      updatedISO: new Date().toISOString(),
+    };
+    await saveConfig({ widgets: cfg.widgets });
+  } catch (err) {
+    console.error(err);
+    alert('Failed to fetch weather');
+  }
+}
+
+export async function renderWidgets(container: HTMLElement): Promise<void> {
+  const cfg = getConfig();
+  mergeConfigDefaults();
+  const wcfg = cfg.widgets;
+  if (wcfg.show === false) {
+    container.innerHTML = '';
+    return;
+  }
+  container.className = 'widgets';
+  container.innerHTML = '';
+
+  const cards: HTMLElement[] = [];
+
+  // Weather card
+  const weatherCard = document.createElement('div');
+  weatherCard.className = 'widget-card weather-card';
+  const menu = buildMenu(container);
+  if (wcfg.weather.current) {
+    const cur = wcfg.weather.current;
+    const iconFn = ICONS[cur.icon || mapCondition(cur.condition)];
+    const icon = document.createElement('span');
+    icon.innerHTML = iconFn();
+    const temp = document.createElement('span');
+    temp.className = 'temp';
+    temp.textContent = `${Math.round(cur.temp)}° ${wcfg.weather.units}`;
+    const line1 = document.createElement('div');
+    line1.className = 'line1';
+    line1.append(icon, temp);
+    const cond = document.createElement('div');
+    cond.textContent = `${cur.condition} • ${cur.location || wcfg.weather.city || ''}`;
+    const upd = document.createElement('div');
+    if (cur.updatedISO) {
+      const d = new Date(cur.updatedISO);
+      upd.className = 'updated';
+      upd.textContent = `Updated ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+    }
+    weatherCard.append(line1, cond, upd);
+  } else {
+    weatherCard.textContent = 'Weather: set in Settings';
+  }
+  weatherCard.appendChild(menu);
+  cards.push(weatherCard);
+
+  // Internal headline
+  const intCard = document.createElement('div');
+  intCard.className = 'widget-card';
+  const intIcon = document.createElement('span');
+  intIcon.innerHTML = iconMegaphone();
+  const intText = document.createElement('span');
+  intText.textContent = wcfg.headlines.internal;
+  intText.title = wcfg.headlines.internal;
+  intCard.append(intIcon, intText);
+  cards.push(intCard);
+
+  // External headline
+  const extCard = document.createElement('div');
+  extCard.className = 'widget-card';
+  const extIcon = document.createElement('span');
+  extIcon.innerHTML = iconCone();
+  const extText = document.createElement('span');
+  extText.textContent = wcfg.headlines.external;
+  extText.title = wcfg.headlines.external;
+  extCard.append(extIcon, extText);
+  cards.push(extCard);
+
+  for (const c of cards) container.appendChild(c);
+}
+
+function buildMenu(container: HTMLElement) {
+  const details = document.createElement('details');
+  details.className = 'widget-menu';
+  const summary = document.createElement('summary');
+  summary.textContent = '⋮';
+  details.appendChild(summary);
+  const menu = document.createElement('div');
+  const btnRef = document.createElement('button');
+  btnRef.textContent = 'Refresh now';
+  btnRef.addEventListener('click', async (e) => {
+    e.preventDefault();
+    details.removeAttribute('open');
+    await fetchWeather();
+    await renderWidgets(container);
+  });
+  const btnHide = document.createElement('button');
+  btnHide.textContent = 'Hide widgets';
+  btnHide.addEventListener('click', async (e) => {
+    e.preventDefault();
+    details.removeAttribute('open');
+    const cfg = getConfig();
+    cfg.widgets.show = false;
+    await saveConfig({ widgets: cfg.widgets });
+    await renderWidgets(container);
+  });
+  menu.append(btnRef, btnHide);
+  details.appendChild(menu);
+  return details;
+}
+


### PR DESCRIPTION
## Summary
- expand app config with widgets defaults
- add widgets panel showing weather and internal/external headlines
- allow configuring widgets and weather settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a28ae85b708327a661b7f689d19a9b