### PR TITLE
Restore main board layout and widget styling

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,7 @@
 :root{
   --bg:#0e1117; --panel:#141925; --text:#f2f5fb; --muted:#aeb9cf; --accent:#4aa3ff;
   --ok:#28c990; --warn:#f5a524; --danger:#ef5b5b; --line:#273044; --slot:#111726;
+  --control:#1a2030; --tab:#1a2435;
   --gap:18px; --radius:14px; --cell:clamp(54px,4.8vh,70px);
   --f:clamp(16px,1.05vw,19px); --f-lg:clamp(19px,1.5vw,24px); --f-xl:clamp(26px,2.4vw,34px);
 }
@@ -11,17 +12,22 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui
 header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-items:center;margin-bottom:var(--gap)}
 .title{font-size:var(--f-xl);font-weight:800;letter-spacing:.2px}
 .subtitle{color:var(--muted);font-size:var(--f)}
-.widgets{display:flex;flex-direction:column;gap:8px}
-.widget-card{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);padding:8px;font-size:var(--f)}
-.widget-card .temp{font-size:var(--f-lg);margin-left:4px}
-.widget-card .updated{color:var(--muted);font-size:.8em}
-.widget-card svg{width:24px;height:24px;margin-right:4px}
-.widget-menu{float:right}
-.widget-menu summary{list-style:none;cursor:pointer}
-.widget-menu div{display:flex;flex-direction:column;background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);position:absolute;margin-top:4px}
-.widget-menu button{background:none;color:var(--text);border:0;padding:4px 8px;text-align:left}
-.widgets,.widget-card{print-color-adjust:exact}
-@media print {
-  body{background:white;color:black}
-  #widgets{display:none!important}
-}
+.layout{display:grid;grid-template-columns:1.6fr 1fr;gap:var(--gap)}
+.panel{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);padding:12px 14px}
+.zones-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:10px}
+@media (max-width:1200px){.zones-grid{grid-template-columns:repeat(3,1fr);}}
+@media (max-width:900px){.layout{grid-template-columns:1fr}.zones-grid{grid-template-columns:repeat(2,1fr);}}
+
+.widget-card{background:var(--panel);border:1px dashed var(--line);border-radius:var(--radius);padding:10px 12px;margin-top:8px}
+.widget-card .w-head{display:flex;align-items:center;gap:8px;justify-content:space-between;color:var(--muted);font-size:0.9em}
+.widget-card .w-body{margin-top:6px}
+.widget-card .w-menu{background:transparent;border:0;color:var(--muted);cursor:pointer}
+
+.form-row{margin:8px 0}
+.form-grid{display:grid;grid-template-columns:repeat(3,minmax(200px,1fr));gap:10px}
+.btn-row{display:flex;gap:8px;margin-top:8px}
+.input,input,select,textarea{background:var(--control);color:var(--text);border:1px solid var(--line);border-radius:8px;padding:6px 8px}
+.btn{background:var(--tab);border:1px solid var(--line);border-radius:8px;padding:6px 10px;cursor:pointer}
+.muted{color:var(--muted)}
+.single-line{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+@media print{#widgets,.widget-card{display:none!important}}

--- a/src/ui/mainTab.ts
+++ b/src/ui/mainTab.ts
@@ -1,15 +1,13 @@
-import { DB, KS, getConfig } from '@/state';
+import { DB, KS, getConfig, STATE } from '@/state';
 import { renderWidgets } from './widgets';
 
-function buildEmptyActive(dateISO: string, shift: 'day' | 'night') {
-  const cfg = getConfig();
-  const zones = Object.fromEntries((cfg.zones || []).map((z: string) => [z, []]));
+function buildEmptyActive(dateISO: string, shift: 'day' | 'night', zones: string[]) {
   return {
     dateISO,
     shift,
     charge: undefined,
     triage: undefined,
-    zones,
+    zones: Object.fromEntries((zones || []).map((z) => [z, [] as any[]])),
     incoming: [],
     offgoing: [],
     support: { techs: [], vols: [], sitters: [] },
@@ -21,18 +19,195 @@ export async function renderMain(
   root: HTMLElement,
   ctx: { dateISO: string; shift: 'day' | 'night' }
 ): Promise<void> {
-  let active = await DB.get(KS.ACTIVE(ctx.dateISO, ctx.shift));
-  if (!active) active = buildEmptyActive(ctx.dateISO, ctx.shift);
-  const cfg = getConfig();
-  for (const z of cfg.zones || []) if (!active.zones[z]) active.zones[z] = [];
   try {
-    root.innerHTML = `<pre>${JSON.stringify(active, null, 2)}</pre>`;
-    const widgets = document.createElement('div');
-    widgets.id = 'widgets';
-    root.appendChild(widgets);
-    await renderWidgets(widgets);
+    const cfg = getConfig();
+    let active: any = await DB.get(KS.ACTIVE(ctx.dateISO, ctx.shift));
+    if (!active) active = buildEmptyActive(ctx.dateISO, ctx.shift, cfg.zones || []);
+
+    root.innerHTML = `
+    <div class="layout">
+      <div class="col col-left">
+        <section class="panel">
+          <h3>Leadership</h3>
+          <div class="slots lead">
+            <div id="slot-charge"></div>
+            <div id="slot-triage"></div>
+          </div>
+        </section>
+
+        <section class="panel">
+          <h3>Assignments (TV Landscape)</h3>
+          <div id="zones" class="zones-grid"></div>
+        </section>
+
+        <section class="panel">
+          <h3>Comments</h3>
+          <textarea id="comments" class="input" placeholder="Current Status..."></textarea>
+        </section>
+      </div>
+
+      <div class="col col-right">
+        <section class="panel">
+          <h3>Physicians (read-only)</h3>
+          <div id="phys"></div>
+        </section>
+
+        <section class="panel">
+          <h3>Support Staff</h3>
+          <div class="support">
+            <label>Techs <input id="techs" placeholder="Comma-separated..."></label>
+            <label>Volunteers <input id="vols" placeholder="Comma-separated..."></label>
+            <label>Sitters <input id="sitters" placeholder="Comma-separated..."></label>
+          </div>
+        </section>
+
+        <section class="panel">
+          <h3>Incoming (click to toggle arrived)</h3>
+          <button id="add-incoming" class="btn">+ Add</button>
+          <div id="incoming"></div>
+        </section>
+
+        <section class="panel">
+          <h3>Off-going (kept 40 min)</h3>
+          <div id="offgoing"></div>
+        </section>
+
+        <section class="panel">
+          <h3>Clock</h3>
+          <div id="clock" class="clock"></div>
+        </section>
+
+        <section id="widgets" class="panel">
+          <h3>Ops Widgets</h3>
+          <div id="widgets-body"></div>
+        </section>
+      </div>
+    </div>
+  `;
+
+    const saveKey = KS.ACTIVE(ctx.dateISO, ctx.shift);
+    let saveTimer: any;
+    const queueSave = () => {
+      clearTimeout(saveTimer);
+      saveTimer = setTimeout(() => DB.set(saveKey, active), 300);
+    };
+
+    renderLeadership(active);
+    renderZones(active, cfg);
+    wireComments(active, queueSave);
+    renderSupport(active, queueSave);
+    renderIncoming(active, queueSave);
+    renderOffgoing(active, queueSave);
+    renderClock();
+    await renderWidgets(document.getElementById('widgets-body')!);
   } catch (err) {
     console.error(err);
-    root.innerHTML = '<p class="error">Failed to render</p>';
+    root.innerHTML = `
+      <section class="panel">
+        <p>Couldn't render board. See console.</p>
+        <button id="reset-tuple" class="btn">Reset tuple</button>
+      </section>
+    `;
+    document.getElementById('reset-tuple')?.addEventListener('click', async () => {
+      await DB.del(KS.ACTIVE(ctx.dateISO, ctx.shift));
+      renderMain(root, ctx);
+    });
   }
+}
+
+function renderLeadership(active: any) {
+  (document.getElementById('slot-charge') as HTMLElement).textContent =
+    active.charge?.nurseId || '';
+  (document.getElementById('slot-triage') as HTMLElement).textContent =
+    active.triage?.nurseId || '';
+}
+
+function renderZones(active: any, cfg: any) {
+  const cont = document.getElementById('zones')!;
+  cont.innerHTML = '';
+  for (const z of cfg.zones || []) {
+    const div = document.createElement('div');
+    const h = document.createElement('h4');
+    h.textContent = z;
+    div.appendChild(h);
+    const list = document.createElement('div');
+    for (const s of active.zones[z] || []) {
+      const item = document.createElement('div');
+      item.textContent = s.nurseId;
+      list.appendChild(item);
+    }
+    div.appendChild(list);
+    cont.appendChild(div);
+  }
+}
+
+function wireComments(active: any, save: () => void) {
+  const el = document.getElementById('comments') as HTMLTextAreaElement;
+  el.value = active.comments || '';
+  el.disabled = STATE.locked;
+  el.addEventListener('input', () => {
+    active.comments = el.value;
+    save();
+  });
+}
+
+function renderSupport(active: any, save: () => void) {
+  const map: Record<string, string> = { techs: 'techs', vols: 'vols', sitters: 'sitters' };
+  for (const [id, key] of Object.entries(map)) {
+    const input = document.getElementById(id) as HTMLInputElement;
+    input.value = active.support[key].join(', ');
+    input.disabled = STATE.locked;
+    input.addEventListener('input', () => {
+      active.support[key] = input.value
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      save();
+    });
+  }
+}
+
+function renderIncoming(active: any, save: () => void) {
+  const cont = document.getElementById('incoming')!;
+  cont.innerHTML = '';
+  active.incoming.forEach((inc: any) => {
+    const div = document.createElement('div');
+    div.textContent = `${inc.nurseId} ${inc.eta}${inc.arrived ? ' ✓' : ''}`;
+    div.addEventListener('click', () => {
+      if (STATE.locked) return;
+      inc.arrived = !inc.arrived;
+      save();
+      renderIncoming(active, save);
+    });
+    cont.appendChild(div);
+  });
+  const btn = document.getElementById('add-incoming') as HTMLButtonElement;
+  btn.disabled = STATE.locked;
+  btn.onclick = () => {
+    if (STATE.locked) return;
+    const nurse = prompt('Nurse ID?');
+    if (!nurse) return;
+    const eta = prompt('ETA?') || '';
+    active.incoming.push({ nurseId: nurse, eta });
+    save();
+    renderIncoming(active, save);
+  };
+}
+
+function renderOffgoing(active: any, save: () => void) {
+  const cont = document.getElementById('offgoing')!;
+  const cutoff = Date.now() - 40 * 60 * 1000;
+  active.offgoing = active.offgoing.filter((o: any) => o.ts > cutoff);
+  cont.innerHTML = '';
+  for (const o of active.offgoing) {
+    const div = document.createElement('div');
+    div.textContent = o.nurseId;
+    cont.appendChild(div);
+  }
+  save();
+}
+
+function renderClock() {
+  const el = document.getElementById('clock');
+  if (el) el.textContent = STATE.clockHHMM;
 }

--- a/src/ui/settingsTab.ts
+++ b/src/ui/settingsTab.ts
@@ -12,100 +12,135 @@ function mapIcon(cond: string) {
 }
 
 export function renderSettingsTab(root: HTMLElement) {
-  const cfg = getConfig();
   mergeConfigDefaults();
+  root.innerHTML = `<div id="settings-widgets"></div>`;
+  renderWidgetsPanel();
+}
+
+function renderWidgetsPanel() {
+  const cfg = getConfig();
   const w = cfg.widgets;
-  root.innerHTML = `
-    <section>
-      <h2>Widgets</h2>
-      <label><input type="checkbox" id="widgets-show" ${w.show !== false ? 'checked' : ''}/> Show widgets</label>
-      <h3>Weather</h3>
-      <label>Mode <select id="weather-mode"><option value="manual">Manual</option><option value="openweather">OpenWeather</option></select></label>
-      <label>Units <select id="weather-units"><option value="F">F</option><option value="C">C</option></select></label>
-      <label>City <input type="text" id="weather-city" value="${w.weather.city || ''}"></label>
-      <label>Lat <input type="number" id="weather-lat" value="${w.weather.lat ?? ''}"></label>
-      <label>Lon <input type="number" id="weather-lon" value="${w.weather.lon ?? ''}"></label>
-      <label>API Key <input type="password" id="weather-api" value="${w.weather.apiKey || ''}"></label>
-      <div id="weather-current" class="muted"></div>
-      <button id="save-weather">Save Weather</button>
-      <button id="fetch-weather">Fetch Now</button>
-      <div id="manual-fields" style="margin-top:8px;display:${w.weather.mode === 'manual' ? 'block' : 'none'}">
-        <label>Temperature <input type="number" id="manual-temp" value="${w.weather.current?.temp ?? ''}"></label>
-        <label>Condition <input type="text" id="manual-cond" value="${w.weather.current?.condition ?? ''}"></label>
-        <label>Location <input type="text" id="manual-loc" value="${w.weather.current?.location ?? ''}"></label>
-      </div>
-      <h3>Headlines</h3>
-      <label>Internal <input type="text" id="headline-int" value="${w.headlines.internal}"></label>
-      <label>External <input type="text" id="headline-ext" value="${w.headlines.external}"></label>
-      <button id="save-headlines">Save Headlines</button>
-    </section>`;
+  const el = document.getElementById('settings-widgets')!;
+  el.innerHTML = `
+  <section class="panel">
+    <h3>Widgets</h3>
 
-  (document.getElementById('weather-mode') as HTMLSelectElement).value = w.weather.mode;
-  (document.getElementById('weather-units') as HTMLSelectElement).value = w.weather.units;
-  const currentEl = document.getElementById('weather-current')!;
-  if (w.weather.current) {
-    const cur = w.weather.current;
-    currentEl.textContent = `${Math.round(cur.temp)}° ${w.weather.units} ${cur.condition} ${cur.location || ''}`;
-  } else currentEl.textContent = '';
+    <div class="form-row">
+      <label><input type="checkbox" id="w-show"> Show widgets</label>
+    </div>
 
-  (document.getElementById('weather-mode') as HTMLSelectElement).addEventListener('change', (e) => {
-    const mode = (e.target as HTMLSelectElement).value;
-    document.getElementById('manual-fields')!.style.display = mode === 'manual' ? 'block' : 'none';
+    <h4>Weather</h4>
+    <div class="form-grid">
+      <label>Mode
+        <select id="w-mode">
+          <option>Manual</option>
+          <option>OpenWeather</option>
+        </select>
+      </label>
+      <label>Units
+        <select id="w-units">
+          <option>F</option><option>C</option>
+        </select>
+      </label>
+      <label>City <input id="w-city" placeholder="Louisville, KY"></label>
+      <label>Lat <input id="w-lat" type="number"></label>
+      <label>Lon <input id="w-lon" type="number"></label>
+      <label>API Key <input id="w-key" type="password"></label>
+    </div>
+    <div class="btn-row"><button id="w-save" class="btn">Save Weather</button><button id="w-fetch" class="btn">Fetch Now</button></div>
+
+    <div id="w-manual" class="form-grid">
+      <label>Temperature <input id="w-temp" type="number"></label>
+      <label>Condition <input id="w-cond"></label>
+      <label>Location <input id="w-loc"></label>
+      <button id="w-apply" class="btn">Apply Manual</button>
+    </div>
+
+    <h4>Headlines</h4>
+    <div class="form-grid">
+      <label>Internal <input id="h-int"></label>
+      <label>External <input id="h-ext"></label>
+    </div>
+    <div class="btn-row"><button id="h-save" class="btn">Save Headlines</button></div>
+  </section>
+`;
+
+  (document.getElementById('w-show') as HTMLInputElement).checked = w.show !== false;
+  (document.getElementById('w-mode') as HTMLSelectElement).value = w.weather.mode === 'openweather' ? 'OpenWeather' : 'Manual';
+  (document.getElementById('w-units') as HTMLSelectElement).value = w.weather.units;
+  (document.getElementById('w-city') as HTMLInputElement).value = w.weather.city || '';
+  (document.getElementById('w-lat') as HTMLInputElement).value = w.weather.lat?.toString() || '';
+  (document.getElementById('w-lon') as HTMLInputElement).value = w.weather.lon?.toString() || '';
+  (document.getElementById('w-key') as HTMLInputElement).value = w.weather.apiKey || '';
+  (document.getElementById('w-temp') as HTMLInputElement).value = w.weather.current?.temp?.toString() || '';
+  (document.getElementById('w-cond') as HTMLInputElement).value = w.weather.current?.condition || '';
+  (document.getElementById('w-loc') as HTMLInputElement).value = w.weather.current?.location || '';
+  (document.getElementById('h-int') as HTMLInputElement).value = w.headlines.internal;
+  (document.getElementById('h-ext') as HTMLInputElement).value = w.headlines.external;
+
+  const manual = document.getElementById('w-manual')!;
+  manual.style.display = w.weather.mode === 'manual' ? 'grid' : 'none';
+  document.getElementById('w-mode')!.addEventListener('change', (e) => {
+    const mode = (e.target as HTMLSelectElement).value.toLowerCase();
+    manual.style.display = mode === 'manual' ? 'grid' : 'none';
   });
 
-  document.getElementById('save-weather')!.addEventListener('click', async () => {
+  document.getElementById('w-save')!.addEventListener('click', async () => {
     const cfg = getConfig();
     const w = cfg.widgets;
-    w.show = (document.getElementById('widgets-show') as HTMLInputElement).checked;
-    const mode = (document.getElementById('weather-mode') as HTMLSelectElement).value as 'manual' | 'openweather';
-    const newUnits = (document.getElementById('weather-units') as HTMLSelectElement).value as 'F' | 'C';
+    w.show = (document.getElementById('w-show') as HTMLInputElement).checked;
+    w.weather.mode = (document.getElementById('w-mode') as HTMLSelectElement).value.toLowerCase() as 'manual' | 'openweather';
     const prevUnits = w.weather.units;
-    w.weather.mode = mode;
-    w.weather.units = newUnits;
-    w.weather.city = (document.getElementById('weather-city') as HTMLInputElement).value || undefined;
-    const lat = parseFloat((document.getElementById('weather-lat') as HTMLInputElement).value);
+    w.weather.units = (document.getElementById('w-units') as HTMLSelectElement).value as 'F' | 'C';
+    w.weather.city = (document.getElementById('w-city') as HTMLInputElement).value || undefined;
+    const lat = parseFloat((document.getElementById('w-lat') as HTMLInputElement).value);
     w.weather.lat = isNaN(lat) ? undefined : lat;
-    const lon = parseFloat((document.getElementById('weather-lon') as HTMLInputElement).value);
+    const lon = parseFloat((document.getElementById('w-lon') as HTMLInputElement).value);
     w.weather.lon = isNaN(lon) ? undefined : lon;
-    w.weather.apiKey = (document.getElementById('weather-api') as HTMLInputElement).value || undefined;
-    if (mode === 'manual') {
-      const temp = parseFloat((document.getElementById('manual-temp') as HTMLInputElement).value);
-      const cond = (document.getElementById('manual-cond') as HTMLInputElement).value;
-      const loc = (document.getElementById('manual-loc') as HTMLInputElement).value;
-      w.weather.current = {
-        temp: temp,
-        condition: cond,
-        location: loc,
-        icon: mapIcon(cond),
-        updatedISO: new Date().toISOString(),
-      };
-    } else if (w.weather.current && prevUnits !== newUnits) {
-      // convert temp on unit change
+    w.weather.apiKey = (document.getElementById('w-key') as HTMLInputElement).value || undefined;
+    if (w.weather.current && prevUnits !== w.weather.units) {
       w.weather.current.temp =
-        newUnits === 'C'
+        w.weather.units === 'C'
           ? ((w.weather.current.temp - 32) * 5) / 9
           : w.weather.current.temp * 9 / 5 + 32;
     }
     await saveConfig({ widgets: w });
-    const container = document.getElementById('widgets');
-    if (container) await renderWidgets(container);
-    renderSettingsTab(root);
+    const body = document.getElementById('widgets-body');
+    if (body) await renderWidgets(body);
   });
 
-  document.getElementById('fetch-weather')!.addEventListener('click', async () => {
+  document.getElementById('w-fetch')!.addEventListener('click', async () => {
     await fetchWeather();
-    const container = document.getElementById('widgets');
-    if (container) await renderWidgets(container);
-    renderSettingsTab(root);
+    const body = document.getElementById('widgets-body');
+    if (body) await renderWidgets(body);
+    renderWidgetsPanel();
   });
 
-  document.getElementById('save-headlines')!.addEventListener('click', async () => {
+  document.getElementById('w-apply')!.addEventListener('click', async () => {
     const cfg = getConfig();
-    cfg.widgets.headlines.internal = (document.getElementById('headline-int') as HTMLInputElement).value;
-    cfg.widgets.headlines.external = (document.getElementById('headline-ext') as HTMLInputElement).value;
+    const w = cfg.widgets;
+    const temp = parseFloat((document.getElementById('w-temp') as HTMLInputElement).value);
+    const cond = (document.getElementById('w-cond') as HTMLInputElement).value;
+    const loc = (document.getElementById('w-loc') as HTMLInputElement).value;
+    w.weather.current = {
+      temp: temp,
+      condition: cond,
+      location: loc,
+      icon: mapIcon(cond),
+      updatedISO: new Date().toISOString(),
+    };
+    await saveConfig({ widgets: w });
+    const body = document.getElementById('widgets-body');
+    if (body) await renderWidgets(body);
+    renderWidgetsPanel();
+  });
+
+  document.getElementById('h-save')!.addEventListener('click', async () => {
+    const cfg = getConfig();
+    cfg.widgets.headlines.internal = (document.getElementById('h-int') as HTMLInputElement).value;
+    cfg.widgets.headlines.external = (document.getElementById('h-ext') as HTMLInputElement).value;
     await saveConfig({ widgets: cfg.widgets });
-    const container = document.getElementById('widgets');
-    if (container) await renderWidgets(container);
-    renderSettingsTab(root);
+    const body = document.getElementById('widgets-body');
+    if (body) await renderWidgets(body);
   });
 }


### PR DESCRIPTION
## Summary
- Reinstate 3-column main board with Ops Widgets panel and remove JSON debug dump
- Add widget cards for weather and headlines and style Widgets settings panel
- Expand CSS with layout, panel, form, and widget styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a28f9feb188327bcc84dd8d555412f