### PR TITLE
feat: allow JSON import of historical shifts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,29 @@ for the UI.
 - `npm run dev` – start the dev server
 - `npm run build` – build for production
 - `npm test` – run unit tests
+
+## Importing historical shifts
+
+Historical board data can be preloaded by importing a JSON string.  The helper
+`importHistoryFromJSON` parses the JSON and stores the result under the
+`HISTORY` key in the app's IndexedDB store.
+
+```ts
+import { importHistoryFromJSON } from '@/state';
+
+await importHistoryFromJSON(
+  JSON.stringify([
+    {
+      dateISO: '2024-01-01',
+      shift: 'day',
+      zones: { Alpha: [{ nurseId: 'robot-01' }] },
+      incoming: [],
+      offgoing: [],
+      support: { techs: [], vols: [], sitters: [] }
+    }
+  ])
+);
+```
+
+The example above seeds a past day shift where a "robot" nurse was assigned to
+zone Alpha.

--- a/src/state.ts
+++ b/src/state.ts
@@ -146,4 +146,10 @@ export const KS = {
   PENDING: (dateISO: string, shift: Shift) => `PENDING:${dateISO}:${shift}`,
 } as const;
 
+export async function importHistoryFromJSON(json: string): Promise<PendingShift[]> {
+  const data = JSON.parse(json) as PendingShift[];
+  await DB.set(KS.HISTORY, data);
+  return data;
+}
+
 export { DB };

--- a/tests/historyImport.spec.ts
+++ b/tests/historyImport.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { importHistoryFromJSON, KS, DB } from '@/state';
+
+describe('history import', () => {
+  it('parses json and stores shifts', async () => {
+    const spy = vi.spyOn(DB, 'set').mockResolvedValue();
+    const json = JSON.stringify([
+      {
+        dateISO: '2024-01-01',
+        shift: 'day',
+        zones: { Alpha: [{ nurseId: 'robot-01' }] },
+        incoming: [],
+        offgoing: [],
+        support: { techs: [], vols: [], sitters: [] }
+      }
+    ]);
+    const result = await importHistoryFromJSON(json);
+    expect(result).toEqual([
+      {
+        dateISO: '2024-01-01',
+        shift: 'day',
+        zones: { Alpha: [{ nurseId: 'robot-01' }] },
+        incoming: [],
+        offgoing: [],
+        support: { techs: [], vols: [], sitters: [] }
+      }
+    ]);
+    expect(spy).toHaveBeenCalledWith(KS.HISTORY, result);
+  });
+});


### PR DESCRIPTION
## Summary
- add `importHistoryFromJSON` helper to persist parsed shift data
- document JSON history import in README
- test JSON import flow with sample robot nurse

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2984af3c08327ab61fa21c8ab9ea1