### PR TITLE
fix: prevent overlay click blocking and default weather fetch

### DIFF
--- a/src/config/weather.ts
+++ b/src/config/weather.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_WEATHER_COORDS = { lat: 38.297078, lon: -85.669624 } as const;

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { renderHeader } from '@/ui/header';
 import { renderTabs, activeTab } from '@/ui/tabs';
 import { renderMain } from '@/ui/mainTab';
 import { renderSettingsTab } from '@/ui/settingsTab';
+import { outlineBlockers } from '@/utils/debug';
 
 export async function renderAll() {
   await renderHeader();
@@ -21,6 +22,7 @@ export async function renderAll() {
       break;
     // other tabs can be added here
   }
+  if (import.meta.env.DEV) outlineBlockers();
 }
 
 initState();

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,5 +1,6 @@
 import { Shift, hhmmNowLocal, toDateISO, deriveShift } from '@/utils/time';
 import * as DB from '@/db';
+import { DEFAULT_WEATHER_COORDS } from '@/config/weather';
 
 export type WidgetsConfig = {
   show?: boolean;
@@ -84,6 +85,8 @@ const WIDGETS_DEFAULTS: WidgetsConfig = {
   weather: {
     mode: 'manual',
     units: 'F',
+    lat: DEFAULT_WEATHER_COORDS.lat,
+    lon: DEFAULT_WEATHER_COORDS.lon,
   },
   headlines: {
     internal: 'Congrats to RN Katie for Daisy Award',

--- a/src/styles.css
+++ b/src/styles.css
@@ -21,6 +21,13 @@
 
   --halo: 0 0 0 1px color-mix(in oklab, currentColor 50%, transparent) inset,
           0 0 18px color-mix(in oklab, currentColor 35%, transparent);
+
+  --z-base: 0;
+  --z-sticky: 100;
+  --z-dropdown: 200;
+  --z-modal: 1000;
+  --z-toast: 1100;
+  --z-drag: 1200;
 }
 
 :root[data-theme='light']{
@@ -35,7 +42,7 @@
 html,body{height:100%}
 body{margin:0;background:var(--bg);color:var(--text-high);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
 .wrap{max-width:1920px;margin:0 auto;padding:var(--gap)}
-header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-items:center;margin-bottom:var(--gap)}
+header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-items:center;margin-bottom:var(--gap);position:sticky;top:0;z-index:var(--z-sticky)}
 .title{font-size:var(--f-xl);font-weight:800;letter-spacing:.2px}
 .subtitle{color:var(--text-muted);font-size:var(--f)}
 .layout{display:grid;grid-template-columns:1.6fr 1fr;gap:var(--gap)}
@@ -78,3 +85,14 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .nurse-pill:focus-visible,.chip:focus-visible{outline:2px solid color-mix(in oklab,currentColor 60%,white 0%);outline-offset:2px}
 
 @media print{#widgets,.widget{display:none!important}}
+
+.backdrop{position:fixed;inset:0;background:rgba(0,0,0,.6);opacity:0;pointer-events:none;transition:opacity .2s;z-index:var(--z-modal)}
+.backdrop.open{opacity:1;pointer-events:auto}
+
+.offcanvas{position:fixed;top:0;right:0;bottom:0;width:300px;background:var(--panel);transform:translateX(100%);pointer-events:none;transition:transform .3s;z-index:var(--z-modal)}
+.offcanvas.open{transform:translateX(0);pointer-events:auto}
+
+.drag-layer{position:fixed;inset:0;pointer-events:none;z-index:var(--z-drag)}
+
+.dropdown{position:absolute;z-index:var(--z-dropdown)}
+.toast{position:fixed;z-index:var(--z-toast)}

--- a/src/ui/settingsTab.ts
+++ b/src/ui/settingsTab.ts
@@ -122,6 +122,14 @@ function renderWidgetsPanel() {
           : w.weather.current.temp * 9 / 5 + 32;
     }
     await saveConfig({ widgets: w });
+    if (
+      w.weather.mode === 'openweather' &&
+      w.weather.apiKey &&
+      w.weather.lat != null &&
+      w.weather.lon != null
+    ) {
+      await fetchWeather();
+    }
     const body = document.getElementById('widgets-body');
     if (body) await renderWidgets(body);
   });

--- a/src/ui/widgets.ts
+++ b/src/ui/widgets.ts
@@ -84,6 +84,18 @@ export async function renderWidgets(container: HTMLElement): Promise<void> {
     container.innerHTML = '';
     return;
   }
+
+  if (
+    wcfg.weather.mode === 'openweather' &&
+    !wcfg.weather.current &&
+    wcfg.weather.apiKey &&
+    wcfg.weather.lat != null &&
+    wcfg.weather.lon != null
+  ) {
+    await fetchWeather();
+    mergeConfigDefaults();
+  }
+
   let html = '';
 
   // Weather card

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,0 +1,13 @@
+export function outlineBlockers(): void {
+  const els = Array.from(document.querySelectorAll<HTMLElement>('body *'));
+  els.forEach((el) => {
+    const style = getComputedStyle(el);
+    if (style.display === 'none') return;
+    if (style.position === 'fixed' || style.position === 'absolute') {
+      const rect = el.getBoundingClientRect();
+      if (rect.width >= window.innerWidth && rect.height >= window.innerHeight) {
+        el.style.outline = '2px dashed red';
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add default weather coordinates and auto-fetch on widgets render
- expose debug helper to outline fullscreen blockers
- define z-index scale and pointer-event-safe overlays

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a296fe3a14832786991e29cd48159e