### PR TITLE
Add pending/history layout stubs and overlay audit

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,8 @@ import { renderHeader } from '@/ui/header';
 import { renderTabs, activeTab } from '@/ui/tabs';
 import { renderMain } from '@/ui/mainTab';
 import { renderSettingsTab } from '@/ui/settingsTab';
+import { renderPendingTab } from '@/ui/pendingTab';
+import { renderHistoryTab } from '@/ui/historyTab';
 import { outlineBlockers } from '@/utils/debug';
 
 export async function renderAll() {
@@ -16,6 +18,12 @@ export async function renderAll() {
   switch (activeTab()) {
     case 'Main':
       await renderMain(root, { dateISO, shift });
+      break;
+    case 'Pending':
+      renderPendingTab(root);
+      break;
+    case 'History':
+      renderHistoryTab(root);
       break;
     case 'Settings':
       renderSettingsTab(root);

--- a/src/styles.css
+++ b/src/styles.css
@@ -22,9 +22,9 @@
   --halo: 0 0 0 1px color-mix(in oklab, currentColor 50%, transparent) inset,
           0 0 18px color-mix(in oklab, currentColor 35%, transparent);
 
-  --z-base: 0;
+  --z-base: 1;
   --z-sticky: 100;
-  --z-dropdown: 200;
+  --z-dropdown: 500;
   --z-modal: 1000;
   --z-toast: 1100;
   --z-drag: 1200;
@@ -86,8 +86,9 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 
 @media print{#widgets,.widget{display:none!important}}
 
-.backdrop{position:fixed;inset:0;background:rgba(0,0,0,.6);opacity:0;pointer-events:none;transition:opacity .2s;z-index:var(--z-modal)}
-.backdrop.open{opacity:1;pointer-events:auto}
+.overlay,.backdrop,.modal-backdrop{position:fixed;inset:0;z-index:var(--z-modal)}
+.overlay:not(.open),.backdrop:not(.open),.modal-backdrop:not(.open){pointer-events:none;opacity:0}
+.backdrop{background:rgba(0,0,0,.6);transition:opacity .2s}
 
 .offcanvas{position:fixed;top:0;right:0;bottom:0;width:300px;background:var(--panel);transform:translateX(100%);pointer-events:none;transition:transform .3s;z-index:var(--z-modal)}
 .offcanvas.open{transform:translateX(0);pointer-events:auto}
@@ -96,3 +97,5 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 
 .dropdown{position:absolute;z-index:var(--z-dropdown)}
 .toast{position:fixed;z-index:var(--z-toast)}
+
+.pending-layout{display:grid;grid-template-columns:320px 1fr 320px;gap:12px;height:100%}

--- a/src/ui/historyTab.ts
+++ b/src/ui/historyTab.ts
@@ -1,3 +1,7 @@
 export function renderHistoryTab(root: HTMLElement) {
-  root.innerHTML = "<p>History tab</p>";
+  root.innerHTML = `
+    <div class="history-page">
+      <p class="muted">No shift history yet.</p>
+    </div>
+  `;
 }

--- a/src/ui/pendingTab.ts
+++ b/src/ui/pendingTab.ts
@@ -1,3 +1,16 @@
 export function renderPendingTab(root: HTMLElement) {
-  root.innerHTML = "<p>Pending tab</p>";
+  root.innerHTML = `
+    <div class="pending-layout">
+      <aside class="panel" id="pending-roster">
+        <input id="roster-search" type="search" placeholder="Search nurses" />
+        <ul id="roster-list"></ul>
+      </aside>
+      <section class="panel" id="pending-board">
+        <p class="muted">Drag nurses here to assign zones.</p>
+      </section>
+      <aside class="panel" id="pending-inspector">
+        <p class="muted">Select a nurse to see details.</p>
+      </aside>
+    </div>
+  `;
 }

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -2,7 +2,7 @@ export function outlineBlockers(): void {
   const els = Array.from(document.querySelectorAll<HTMLElement>('body *'));
   els.forEach((el) => {
     const style = getComputedStyle(el);
-    if (style.display === 'none') return;
+    if (style.display === 'none' || style.pointerEvents === 'none') return;
     if (style.position === 'fixed' || style.position === 'absolute') {
       const rect = el.getBoundingClientRect();
       if (rect.width >= window.innerWidth && rect.height >= window.innerHeight) {


### PR DESCRIPTION
## Summary
- add audit for large overlays so only click-targets are highlighted
- define overlay styles and pending page grid layout
- scaffold Pending and History tabs and wire into main renderer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a29cee90d4832789af80903e612911