### PR TITLE
feat: implement pending board layout

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -149,6 +149,14 @@ export const KS = {
   PENDING: (dateISO: string, shift: Shift) => `PENDING:${dateISO}:${shift}`,
 } as const;
 
+export async function loadStaff(): Promise<Staff[]> {
+  return (await DB.get<Staff[]>(KS.STAFF)) || [];
+}
+
+export async function saveStaff(list: Staff[]): Promise<void> {
+  await DB.set(KS.STAFF, list);
+}
+
 export async function importHistoryFromJSON(json: string): Promise<PendingShift[]> {
   const data = JSON.parse(json) as PendingShift[];
   await DB.set(KS.HISTORY, data);

--- a/src/styles.css
+++ b/src/styles.css
@@ -99,3 +99,16 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .toast{position:fixed;z-index:var(--z-toast)}
 
 .pending-layout{display:grid;grid-template-columns:320px 1fr 320px;gap:12px;height:100%}
+.pending-layout .panel{display:flex;flex-direction:column}
+.roster-panel{overflow:hidden}
+.roster-controls{display:flex;flex-direction:column;gap:6px}
+#roster-list{list-style:none;padding:0;margin:8px 0;flex:1;overflow:auto}
+#roster-list li{padding:4px 6px;border-radius:6px;cursor:grab}
+#roster-list li.selected{background:var(--control)}
+.board-panel{overflow:auto}
+.zone{margin-bottom:8px}
+.zone h4{display:flex;justify-content:space-between;align-items:center;margin:0}
+.zone .slots{min-height:40px;border:1px dashed var(--line);padding:4px;border-radius:8px}
+.slot{padding:4px 6px;margin:2px 0;background:var(--control);border-radius:6px;cursor:grab}
+.flags-panel ul{list-style:none;padding:0;margin:0;flex:1;overflow:auto}
+.flags-panel li{padding:4px 0}

--- a/src/ui/pendingTab.ts
+++ b/src/ui/pendingTab.ts
@@ -1,16 +1,246 @@
-export function renderPendingTab(root: HTMLElement) {
+import { STATE, DB, KS, getConfig, saveConfig, loadStaff, saveStaff, Staff } from '@/state';
+import { Board, upsertSlot, moveSlot, removeSlot } from '@/slots';
+
+export async function renderPendingTab(root: HTMLElement) {
+  const cfg = getConfig();
+  let staff: Staff[] = await loadStaff();
+  let board: Board =
+    (await DB.get<Board>(KS.PENDING(STATE.dateISO, STATE.shift))) || {
+      charge: undefined,
+      triage: undefined,
+      zones: Object.fromEntries((cfg.zones || []).map((z) => [z, [] as any[]])),
+    };
+  let selected: string | undefined;
+
   root.innerHTML = `
     <div class="pending-layout">
-      <aside class="panel" id="pending-roster">
-        <input id="roster-search" type="search" placeholder="Search nurses" />
+      <aside class="panel roster-panel">
+        <div class="roster-controls">
+          <input id="roster-search" type="search" placeholder="Search nurses" />
+          <select id="roster-filter">
+            <option value="">All Types</option>
+            <option value="home">Home</option>
+            <option value="travel">Travel</option>
+            <option value="float">Float</option>
+            <option value="charge">Charge</option>
+            <option value="triage">Triage</option>
+            <option value="other">Other</option>
+          </select>
+        </div>
         <ul id="roster-list"></ul>
+        <button id="nurse-edit" class="btn">+ Add Nurse</button>
       </aside>
-      <section class="panel" id="pending-board">
-        <p class="muted">Drag nurses here to assign zones.</p>
+      <section class="panel board-panel">
+        <div class="zone" data-zone="charge">
+          <h4>Charge</h4>
+          <div class="slots" id="zone-charge"></div>
+        </div>
+        <div class="zone" data-zone="triage">
+          <h4>Triage</h4>
+          <div class="slots" id="zone-triage"></div>
+        </div>
+        <div id="zones"></div>
+        <button id="add-zone" class="btn">+ Add Zone</button>
       </section>
-      <aside class="panel" id="pending-inspector">
-        <p class="muted">Select a nurse to see details.</p>
+      <aside class="panel flags-panel">
+        <h3>Flags</h3>
+        <ul id="flags-list"></ul>
       </aside>
     </div>
   `;
+
+  const saveBoard = async () => {
+    await DB.set(KS.PENDING(STATE.dateISO, STATE.shift), board);
+    renderFlags();
+  };
+
+  function renderRoster() {
+    const search = (document.getElementById('roster-search') as HTMLInputElement).value.toLowerCase();
+    const filter = (document.getElementById('roster-filter') as HTMLSelectElement).value as Staff['type'] | '';
+    const list = document.getElementById('roster-list')!;
+    list.innerHTML = '';
+    staff
+      .filter(
+        (s) => (!filter || s.type === filter) && (!search || s.name.toLowerCase().includes(search))
+      )
+      .forEach((s) => {
+        const li = document.createElement('li');
+        li.textContent = s.name;
+        li.draggable = true;
+        li.dataset.id = s.id;
+        if (selected === s.id) li.classList.add('selected');
+        li.addEventListener('click', () => {
+          selected = selected === s.id ? undefined : s.id;
+          renderRoster();
+        });
+        li.addEventListener('dragstart', (e) => {
+          e.dataTransfer?.setData('nurse', s.id);
+        });
+        list.appendChild(li);
+      });
+    const btn = document.getElementById('nurse-edit') as HTMLButtonElement;
+    btn.textContent = selected ? 'Edit Nurse' : '+ Add Nurse';
+  }
+
+  function placeholder(): HTMLElement {
+    const p = document.createElement('p');
+    p.className = 'muted';
+    p.textContent = 'Drop nurse here';
+    return p;
+  }
+
+  function renderSlot(slot: any, target: any): HTMLElement {
+    const div = document.createElement('div');
+    div.className = 'slot';
+    div.textContent = slot.nurseId;
+    div.draggable = true;
+    div.addEventListener('dragstart', (e) => {
+      e.dataTransfer?.setData('slot', JSON.stringify(target));
+    });
+    div.addEventListener('dblclick', () => {
+      removeSlot(board, target);
+      saveBoard();
+      renderBoard();
+    });
+    return div;
+  }
+
+  function makeDroppable(el: HTMLElement, target: any) {
+    el.addEventListener('dragover', (e) => e.preventDefault());
+    el.addEventListener('drop', (e) => {
+      e.preventDefault();
+      const nurse = e.dataTransfer?.getData('nurse');
+      const from = e.dataTransfer?.getData('slot');
+      if (nurse) {
+        upsertSlot(board, target, { nurseId: nurse });
+      } else if (from) {
+        moveSlot(board, JSON.parse(from), target);
+      }
+      saveBoard();
+      renderBoard();
+    });
+  }
+
+  function renderBoard() {
+    const chargeEl = document.getElementById('zone-charge')!;
+    chargeEl.innerHTML = '';
+    makeDroppable(chargeEl, 'charge');
+    if (board.charge) chargeEl.appendChild(renderSlot(board.charge, 'charge'));
+    else chargeEl.appendChild(placeholder());
+
+    const triageEl = document.getElementById('zone-triage')!;
+    triageEl.innerHTML = '';
+    makeDroppable(triageEl, 'triage');
+    if (board.triage) triageEl.appendChild(renderSlot(board.triage, 'triage'));
+    else triageEl.appendChild(placeholder());
+
+    const zonesCont = document.getElementById('zones')!;
+    zonesCont.innerHTML = '';
+    for (const z of Object.keys(board.zones)) {
+      const wrap = document.createElement('div');
+      wrap.className = 'zone';
+      wrap.dataset.zone = z;
+      const h = document.createElement('h4');
+      h.innerHTML = `${z} <button class="remove-zone" data-zone="${z}">×</button>`;
+      wrap.appendChild(h);
+      const slots = document.createElement('div');
+      slots.className = 'slots';
+      slots.id = `zone-${z}`;
+      makeDroppable(slots, { zone: z });
+      if (board.zones[z].length === 0) slots.appendChild(placeholder());
+      board.zones[z].forEach((s, i) => slots.appendChild(renderSlot(s, { zone: z, index: i })));
+      wrap.appendChild(slots);
+      zonesCont.appendChild(wrap);
+    }
+  }
+
+  function renderFlags() {
+    const list = document.getElementById('flags-list')!;
+    const counts = new Map<string, string[]>();
+    if (board.charge) counts.set(board.charge.nurseId, ['Charge']);
+    if (board.triage) {
+      const arr = counts.get(board.triage.nurseId) || [];
+      arr.push('Triage');
+      counts.set(board.triage.nurseId, arr);
+    }
+    for (const [zone, slots] of Object.entries(board.zones)) {
+      slots.forEach((s) => {
+        const arr = counts.get(s.nurseId) || [];
+        arr.push(zone);
+        counts.set(s.nurseId, arr);
+      });
+    }
+    const flags = Array.from(counts.entries())
+      .filter(([_, arr]) => arr.length > 1)
+      .sort((a, b) => b[1].length - a[1].length);
+    list.innerHTML = '';
+    if (flags.length === 0) {
+      const li = document.createElement('li');
+      li.className = 'muted';
+      li.textContent = 'No flags';
+      list.appendChild(li);
+    } else {
+      flags.forEach(([id, arr]) => {
+        const li = document.createElement('li');
+        li.textContent = `${id} assigned to ${arr.join(', ')}`;
+        list.appendChild(li);
+      });
+    }
+  }
+
+  function wireUI() {
+    (document.getElementById('roster-search') as HTMLInputElement).addEventListener('input', renderRoster);
+    (document.getElementById('roster-filter') as HTMLSelectElement).addEventListener('change', renderRoster);
+    document.getElementById('nurse-edit')!.addEventListener('click', async () => {
+      if (selected) {
+        const nurse = staff.find((s) => s.id === selected)!;
+        const name = prompt('Name', nurse.name);
+        if (!name) return;
+        const type = (prompt('Type', nurse.type) as Staff['type']) || nurse.type;
+        nurse.name = name;
+        nurse.type = type;
+      } else {
+        const name = prompt('Name?');
+        if (!name) return;
+        const type =
+          (prompt('Type? (home, travel, float, charge, triage, other)', 'home') as Staff['type']) ||
+          'home';
+        staff.push({ id: crypto.randomUUID(), name, type });
+      }
+      await saveStaff(staff);
+      selected = undefined;
+      renderRoster();
+    });
+
+    document.getElementById('add-zone')!.addEventListener('click', async () => {
+      const name = prompt('Zone name?');
+      if (!name || board.zones[name]) return;
+      board.zones[name] = [];
+      const cfg = getConfig();
+      cfg.zones.push(name);
+      await saveConfig({ zones: cfg.zones });
+      await saveBoard();
+      renderBoard();
+    });
+
+    document.getElementById('zones')!.addEventListener('click', async (ev) => {
+      const btn = (ev.target as HTMLElement).closest('.remove-zone') as HTMLElement | null;
+      if (btn) {
+        const z = btn.dataset.zone!;
+        if (confirm(`Remove zone ${z}?`)) {
+          delete board.zones[z];
+          const cfg = getConfig();
+          cfg.zones = cfg.zones.filter((s) => s !== z);
+          await saveConfig({ zones: cfg.zones });
+          await saveBoard();
+          renderBoard();
+        }
+      }
+    });
+  }
+
+  renderRoster();
+  renderBoard();
+  renderFlags();
+  wireUI();
 }


### PR DESCRIPTION
## Summary
- add three-column pending board with roster, zone board and flags panel
- enable nurse CRUD and drag-and-drop zone assignments
- store staff roster and pending assignments in IndexedDB

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2a1f3cc208327823bc774ceb71e54