### PR TITLE
Auto-apply pending roster at shift change

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import './styles.css';
 
-import { STATE, initState } from '@/state';
+import { STATE, initState, applyPendingToActive } from '@/state';
 import { hhmmNowLocal, deriveShift } from '@/utils/time';
 import { renderHeader } from '@/ui/header';
 import { renderTabs, activeTab } from '@/ui/tabs';
@@ -35,8 +35,14 @@ export async function renderAll() {
 
 initState();
 renderAll();
-setInterval(() => {
-  STATE.clockHHMM = hhmmNowLocal();
-  STATE.shift = deriveShift(STATE.clockHHMM);
+setInterval(async () => {
+  const hhmm = hhmmNowLocal();
+  const shift = deriveShift(hhmm);
+  if (shift !== STATE.shift) {
+    initState();
+    await applyPendingToActive(STATE.dateISO, STATE.shift);
+  } else {
+    STATE.clockHHMM = hhmm;
+  }
   renderAll();
 }, 1000);

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -174,4 +174,14 @@ export async function importHistoryFromJSON(json: string): Promise<PendingShift[
   return data;
 }
 
+export async function applyPendingToActive(
+  dateISO: string,
+  shift: Shift
+): Promise<void> {
+  const pending = await DB.get<PendingShift>(KS.PENDING(dateISO, shift));
+  if (!pending) return;
+  await DB.set(KS.ACTIVE(dateISO, shift), pending);
+  await DB.del(KS.PENDING(dateISO, shift));
+}
+
 export { DB };

--- a/tests/pendingApply.spec.ts
+++ b/tests/pendingApply.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const store = new Map<string, any>();
+vi.mock('@/db', () => ({
+  get: async (k: string) => store.get(k),
+  set: async (k: string, v: any) => {
+    store.set(k, v);
+  },
+  del: async (k: string) => {
+    store.delete(k);
+  },
+  keys: async (prefix = '') =>
+    Array.from(store.keys()).filter((k) => k.startsWith(prefix)),
+}));
+
+import { applyPendingToActive, KS, DB, type PendingShift } from '@/state';
+
+async function clearDB() {
+  store.clear();
+}
+
+describe('applyPendingToActive', () => {
+  beforeEach(async () => {
+    await clearDB();
+  });
+
+  it('moves pending roster into active and clears pending entry', async () => {
+    const board: PendingShift = {
+      dateISO: '2024-01-01',
+      shift: 'day',
+      charge: { nurseId: '1' },
+      triage: undefined,
+      zones: { A: [{ nurseId: '2' }] },
+      incoming: [],
+      offgoing: [],
+      support: { techs: [], vols: [], sitters: [] },
+    };
+    const key = KS.PENDING(board.dateISO, board.shift);
+    await DB.set(key, board);
+
+    await applyPendingToActive(board.dateISO, board.shift);
+
+    expect(await DB.get(KS.ACTIVE(board.dateISO, board.shift))).toEqual(board);
+    expect(await DB.get(KS.PENDING(board.dateISO, board.shift))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add helper to move pending schedule into active board
- auto-run pending->active handoff on shift change
- test applying pending board

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2b43af3948327b7ada1d214ac3d26