### PR TITLE
feat: track shift lifecycle stages

### DIFF
--- a/src/state/handoff.ts
+++ b/src/state/handoff.ts
@@ -55,6 +55,7 @@ const store: { state: HandoffState } = {
         startAt,
         endAt,
         assignments: [],
+        status: 'draft',
       };
       const list = loadShifts();
       list.push(shift);

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -157,6 +157,7 @@ export const KS = {
   HISTORY: "HISTORY",
   PHYS: (dateISO: string) => `PHYS:${dateISO}`,
   ACTIVE: (dateISO: string, shift: Shift) => `ACTIVE:${dateISO}:${shift}`,
+  ONBAT: (dateISO: string, shift: Shift) => `ONBAT:${dateISO}:${shift}`,
   PENDING: (dateISO: string, shift: Shift) => `PENDING:${dateISO}:${shift}`,
 } as const;
 

--- a/src/types/shifts.ts
+++ b/src/types/shifts.ts
@@ -1,5 +1,7 @@
 export type ShiftId = string;
 
+export type ShiftStatus = 'draft' | 'onbat' | 'live' | 'archived';
+
 export type Shift = {
   id: ShiftId;
   code: string; // e.g., 20250818-D
@@ -8,6 +10,7 @@ export type Shift = {
   endAt: string; // ISO string
   assignments: { nurseId: string; zoneId: string }[];
   notes?: string;
+  status: ShiftStatus;
 };
 
 export type Handoff = {

--- a/tests/keys.spec.ts
+++ b/tests/keys.spec.ts
@@ -5,6 +5,7 @@ describe("KS helpers", () => {
   it("produces key strings", () => {
     expect(KS.PHYS("2024-01-01")).toBe("PHYS:2024-01-01");
     expect(KS.ACTIVE("2024-01-01", "day")).toBe("ACTIVE:2024-01-01:day");
+    expect(KS.ONBAT("2024-01-01", "day")).toBe("ONBAT:2024-01-01:day");
     expect(KS.PENDING("2024-01-01", "night")).toBe("PENDING:2024-01-01:night");
   });
 });


### PR DESCRIPTION
## Summary
- support shift lifecycle statuses: draft, onbat, live, archived
- create shifts with draft status during handoff
- add ONBAT key helper and cover it in tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2bad3c26c8327b88ffd12f016c9a7