### PR TITLE
feat: add theme toggle and font scaling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import './styles.css';
 
-import { STATE, initState, applyDraftToActive } from '@/state';
+import { STATE, initState, applyDraftToActive, loadConfig, applyThemeAndScale } from '@/state';
 import { hhmmNowLocal, deriveShift } from '@/utils/time';
 import { renderHeader } from '@/ui/header';
 import { renderTabs, activeTab } from '@/ui/tabs';
@@ -11,6 +11,7 @@ import { renderHistoryTab } from '@/ui/historyTab';
 import { outlineBlockers } from '@/utils/debug';
 
 export async function renderAll() {
+  applyThemeAndScale();
   await renderHeader();
   await renderTabs();
   const root = document.getElementById('panel')!;
@@ -40,15 +41,18 @@ export async function manualHandoff() {
 }
 
 initState();
-renderAll();
-setInterval(async () => {
-  const hhmm = hhmmNowLocal();
-  const shift = deriveShift(hhmm);
-  if (shift !== STATE.shift) {
-    initState();
-    await applyDraftToActive(STATE.dateISO, STATE.shift);
-  } else {
-    STATE.clockHHMM = hhmm;
-  }
+loadConfig().then(() => {
+  applyThemeAndScale();
   renderAll();
-}, 1000);
+  setInterval(async () => {
+    const hhmm = hhmmNowLocal();
+    const shift = deriveShift(hhmm);
+    if (shift !== STATE.shift) {
+      initState();
+      await applyDraftToActive(STATE.dateISO, STATE.shift);
+    } else {
+      STATE.clockHHMM = hhmm;
+    }
+    renderAll();
+  }, 1000);
+});

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -33,6 +33,8 @@ export type Config = {
   pin: string;
   relockMin: number;
   widgets: WidgetsConfig;
+  theme?: 'light' | 'dark';
+  fontScale?: number;
 };
 
 export type Staff = {
@@ -112,10 +114,18 @@ let CONFIG_CACHE: Config = {
   pin: '4911',
   relockMin: 0,
   widgets: structuredClone(WIDGETS_DEFAULTS),
+  theme: 'dark',
+  fontScale: 1,
 };
 
 export function getConfig(): Config {
   return CONFIG_CACHE;
+}
+
+export function applyThemeAndScale(cfg: Config = CONFIG_CACHE) {
+  const root = document.documentElement;
+  root.setAttribute('data-theme', cfg.theme === 'light' ? 'light' : 'dark');
+  root.style.setProperty('--scale', String(cfg.fontScale ?? 1));
 }
 
 export async function loadConfig(): Promise<Config> {
@@ -151,6 +161,9 @@ export function mergeConfigDefaults(): Config {
       ...cfg.widgets.headlines,
     };
   }
+
+  cfg.theme = cfg.theme === 'light' ? 'light' : 'dark';
+  cfg.fontScale = cfg.fontScale && !isNaN(cfg.fontScale) ? cfg.fontScale : 1;
 
   CONFIG_CACHE = cfg as Config;
   return CONFIG_CACHE;

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,7 +3,9 @@
   --ok:#28c990; --warn:#f5a524; --danger:#ef5b5b; --line:#273044; --slot:#111726;
   --control:#1a2030; --tab:#1a2435;
   --gap:18px; --radius:14px; --cell:clamp(54px,4.8vh,70px);
-  --f:clamp(16px,1.05vw,19px); --f-lg:clamp(19px,1.5vw,24px); --f-xl:clamp(26px,2.4vw,34px);
+  --scale:1;
+  --f-base:clamp(16px,1.05vw,19px); --f-lg-base:clamp(19px,1.5vw,24px); --f-xl-base:clamp(26px,2.4vw,34px);
+  --f:calc(var(--f-base)*var(--scale)); --f-lg:calc(var(--f-lg-base)*var(--scale)); --f-xl:calc(var(--f-xl-base)*var(--scale));
 
   --elev-1: 0 2px 8px rgba(0,0,0,.25);
   --elev-2: 0 6px 20px rgba(0,0,0,.35);
@@ -31,6 +33,11 @@
 }
 
 :root[data-theme='light']{
+  --bg:#f7f9fc;
+  --panel:#ffffff;
+  --control:#f0f2f7;
+  --tab:#e2e6ef;
+  --line:#c5d0e1;
   --text-high:#1A2233;
   --text-med:#2C3A52;
   --text-muted:#54627A;
@@ -45,6 +52,10 @@ body{margin:0;background:var(--bg);color:var(--text-high);font-family:Inter,syst
 header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-items:center;margin-bottom:var(--gap);position:sticky;top:0;z-index:var(--z-sticky)}
 .title{font-size:var(--f-xl);font-weight:800;letter-spacing:.2px}
 .subtitle{color:var(--text-muted);font-size:var(--f)}
+.time-block{text-align:right}
+.clock-big{font-size:var(--f-xl);font-weight:700;line-height:1}
+.date-small{font-size:var(--f);color:var(--text-muted)}
+.actions{display:flex;gap:var(--gap);align-items:center}
 .layout{display:grid;grid-template-columns:1.6fr 1fr;gap:var(--gap)}
 .panel{background:var(--panel);color:var(--text-high);border:1px solid var(--line);border-radius:var(--radius);padding:12px 14px;box-shadow:var(--elev-1)}
 .panel h3{color:var(--text-high);font-size:clamp(14px,.95vw,16px)}

--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -1,4 +1,4 @@
-import { STATE } from '@/state';
+import { STATE, getConfig, saveConfig, applyThemeAndScale } from '@/state';
 import { deriveShift, fmtLong } from '@/utils/time';
 import { manualHandoff } from '@/main';
 
@@ -13,9 +13,24 @@ export function renderHeader() {
   const shift = deriveShift(STATE.clockHHMM);
   const shiftLabel = shift === "day" ? "Day (07–19)" : "Night (19–07)";
   header.innerHTML = `
-    <div class="title">ED Staffing Board</div>
-    <div class="subtitle">${fmtLong(STATE.dateISO)} • Active: ${shiftLabel}</div>
-    <button id="handoff" class="btn">Sign-out</button>
+    <div class="title-block">
+      <div class="title">ED Staffing Board</div>
+      <div class="subtitle">Active: ${shiftLabel}</div>
+    </div>
+    <div class="time-block">
+      <div class="clock-big">${STATE.clockHHMM}</div>
+      <div class="date-small">${fmtLong(STATE.dateISO)}</div>
+    </div>
+    <div class="actions">
+      <button id="theme-toggle" class="btn">🌓</button>
+      <button id="handoff" class="btn">Sign-out</button>
+    </div>
   `;
   document.getElementById('handoff')!.addEventListener('click', manualHandoff);
+  document.getElementById('theme-toggle')!.addEventListener('click', async () => {
+    const cfg = getConfig();
+    const next = cfg.theme === 'light' ? 'dark' : 'light';
+    await saveConfig({ theme: next });
+    applyThemeAndScale({ ...cfg, theme: next });
+  });
 }

--- a/src/ui/settingsTab.ts
+++ b/src/ui/settingsTab.ts
@@ -1,4 +1,4 @@
-import { getConfig, saveConfig, mergeConfigDefaults } from '@/state';
+import { getConfig, saveConfig, mergeConfigDefaults, applyThemeAndScale } from '@/state';
 import { fetchWeather, renderWidgets } from './widgets';
 
 function mapIcon(cond: string) {
@@ -13,7 +13,8 @@ function mapIcon(cond: string) {
 
 export function renderSettingsTab(root: HTMLElement) {
   mergeConfigDefaults();
-  root.innerHTML = `<div id="settings-widgets"></div><div id="type-legend"></div>`;
+  root.innerHTML = `<div id="display-settings"></div><div id="settings-widgets"></div><div id="type-legend"></div>`;
+  renderDisplaySettings();
   renderWidgetsPanel();
   renderTypeLegend();
 }
@@ -167,5 +168,29 @@ function renderWidgetsPanel() {
     await saveConfig({ widgets: cfg.widgets });
     const body = document.getElementById('widgets-body');
     if (body) await renderWidgets(body);
+  });
+}
+
+function renderDisplaySettings() {
+  const cfg = getConfig();
+  const el = document.getElementById('display-settings')!;
+  el.innerHTML = `
+  <section class="panel">
+    <h3>Display</h3>
+    <div class="form-row">
+      <label>Font size
+        <select id="font-scale">
+          <option value="1">Normal</option>
+          <option value="1.2">Large</option>
+          <option value="1.4">Extra Large</option>
+        </select>
+      </label>
+    </div>
+  </section>`;
+  (document.getElementById('font-scale') as HTMLSelectElement).value = (cfg.fontScale || 1).toString();
+  document.getElementById('font-scale')!.addEventListener('change', async (e) => {
+    const scale = parseFloat((e.target as HTMLSelectElement).value);
+    await saveConfig({ fontScale: scale });
+    applyThemeAndScale({ ...cfg, fontScale: scale });
   });
 }


### PR DESCRIPTION
## Summary
- add configurable theme and font scaling
- expose theme switch in header with live clock/date
- allow adjusting font size from settings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adbe138ca48327a013813e65ca7c8d