### PR TITLE
Stabilize inputs and seed default staff/zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+- fix: prevent full app re-render on clock tick to stop input focus loss; throttle weather updates.
+- feat: seed defaults via `staff_and_zones.json` and `seedDefaults()`; enforce canonical zones.
+- feat: normalize staff roles to `nurse` or `tech` with prefixed IDs (`00-`), update UI and imports.
+- feat: add DTO action sending staff to offgoing for 60 min and logging in history.
+- chore: add pastel zone colors and ensure canonical zones can't be removed.

--- a/src/seedDefaults.ts
+++ b/src/seedDefaults.ts
@@ -1,0 +1,25 @@
+import data from '../staff_and_zones.json';
+import { getConfig, saveConfig, loadStaff, saveStaff, Staff } from '@/state';
+import { ensureStaffId } from '@/utils/id';
+
+export const CANONICAL_ZONES = data.zones.map((z) => z.name);
+
+/** Seed default staff and zones if none exist. Idempotent. */
+export async function seedDefaults(): Promise<void> {
+  const cfg = getConfig();
+  if (!cfg.zones || cfg.zones.length === 0) {
+    await saveConfig({ zones: [...CANONICAL_ZONES] });
+  } else {
+    const merged = [...cfg.zones];
+    for (const name of CANONICAL_ZONES) {
+      if (!merged.includes(name)) merged.push(name);
+    }
+    await saveConfig({ zones: merged });
+  }
+
+  let staff = await loadStaff();
+  if (staff.length === 0) {
+    staff = data.staff.map((s) => ({ ...s, id: ensureStaffId(s.id) })) as Staff[];
+    await saveStaff(staff);
+  }
+}

--- a/src/ui/draftTab.ts
+++ b/src/ui/draftTab.ts
@@ -11,6 +11,8 @@ import {
 } from '@/state';
 import { setNurseCache, labelFromId, formatShortName } from '@/utils/names';
 import { upsertSlot, moveSlot, removeSlot } from '@/slots';
+import { createStaffId } from '@/utils/id';
+import { CANONICAL_ZONES } from '@/seedDefaults';
 import {
   seedZonesIfNeeded,
   getDefaultRosterForLabel,
@@ -300,7 +302,7 @@ export async function renderDraftTab(root: HTMLElement) {
         const type =
           (prompt('Type? (home, travel, flex, charge, triage, other)', 'home') as Staff['type']) ||
           'home';
-        staff.push({ id: crypto.randomUUID(), name, type });
+        staff.push({ id: createStaffId(), name, type });
       }
       await saveStaff(staff);
       setNurseCache(staff);
@@ -325,6 +327,7 @@ export async function renderDraftTab(root: HTMLElement) {
       const btn = (ev.target as HTMLElement).closest('.remove-zone') as HTMLElement | null;
       if (btn) {
         const z = btn.dataset.zone!;
+        if (CANONICAL_ZONES.includes(z)) return;
         if (confirm(`Remove zone ${z}?`)) {
           delete board.zones[z];
           const cfg = getConfig();

--- a/src/ui/nurseTile.ts
+++ b/src/ui/nurseTile.ts
@@ -27,10 +27,10 @@ export function nurseTile(slot: Slot, staff: Staff): string {
   if (slot.student) statuses.push('has student');
   if (slot.comment) statuses.push('has comment');
   if (slot.bad) statuses.push('marked bad');
-  const aria = `${name}, ${staff.type} nurse${
+  const aria = `${name}, ${staff.type} ${staff.role}${
     statuses.length ? ', ' + statuses.join(', ') : ''
   }`;
   const chipStr = chips.length ? `<span class="chips">${chips.join('')}</span>` : '';
-  return `<div class="nurse-pill" data-type="${staff.type}" tabindex="0" aria-label="${aria}"><span class="nurse-name">${name}</span>${chipStr}</div>`;
+  return `<div class="nurse-pill" data-type="${staff.type}" data-role="${staff.role}" tabindex="0" aria-label="${aria}"><span class="nurse-name">${name}</span>${chipStr}</div>`;
 }
 

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,0 +1,8 @@
+export function createStaffId(): string {
+  const uuid = crypto.randomUUID();
+  return `00-${uuid}`;
+}
+
+export function ensureStaffId(id: string): string {
+  return id.startsWith('00-') ? id : `00-${id}`;
+}

--- a/staff_and_zones.json
+++ b/staff_and_zones.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "zones": [
+    { "id": "z-01", "name": "Rooms 1-7 & 10", "color": "#f6e5f5" },
+    { "id": "z-02", "name": "Rooms 8-12", "color": "#e5f0ff" },
+    { "id": "z-03", "name": "Rooms 13-16", "color": "#e5fff8" },
+    { "id": "z-04", "name": "Rooms 17-20", "color": "#fffbe5" },
+    { "id": "z-05", "name": "Rooms 21-24", "color": "#ffe5e5" },
+    { "id": "z-06", "name": "Faster", "color": "#e5ffe5" },
+    { "id": "z-07", "name": "Cardiac Obs", "color": "#e5e5ff" }
+  ],
+  "staff": [
+    { "id": "00-aaaaaa-001", "name": "Alice Nurse", "role": "nurse" },
+    { "id": "00-bbbbbb-001", "name": "Bob Tech", "role": "tech" }
+  ],
+  "by_role": {
+    "nurse": ["00-aaaaaa-001"],
+    "tech": ["00-bbbbbb-001"]
+  }
+}

--- a/tests/slots.spec.ts
+++ b/tests/slots.spec.ts
@@ -33,6 +33,7 @@ describe("break toggles", () => {
     const html = renderTile(slot, {
       id: "1",
       name: "Alice",
+      role: "nurse",
       type: "other",
     });
     expect(html).toContain("⏸️");
@@ -44,8 +45,8 @@ describe("break toggles", () => {
 describe("employee ID uniqueness", () => {
   it("detects conflicts", () => {
     const staff = [
-      { id: "1", name: "A", type: "other" },
-      { id: "2", name: "B", type: "other" },
+      { id: "1", name: "A", role: "nurse", type: "other" },
+      { id: "2", name: "B", role: "nurse", type: "other" },
     ];
     expect(isEmployeeIdUnique(staff, "3")).toBe(true);
     expect(isEmployeeIdUnique(staff, "2")).toBe(false);
@@ -72,10 +73,11 @@ describe("nurse tile snapshot", () => {
     const html = renderTile(slot, {
       id: "1",
       name: "Alice",
+      role: "nurse",
       type: "other",
     });
     expect(html).toMatchInlineSnapshot(
-      `"<div class=\"nurse-pill\" data-type=\"other\" tabindex=\"0\" aria-label=\"Alice, other nurse, on break, has student, has comment, marked bad\"><span class=\"nurse-name\">Alice</span><span class=\"chips\"><span class=\"chip\" aria-label=\"On break\"><span class=\"icon\">⏸️</span></span><span class=\"chip\" aria-label=\"Has student\"><span class=\"icon\">🎓</span></span><span class=\"chip\" aria-label=\"Has comment\"><span class=\"icon\">💬</span></span><span class=\"chip\" aria-label=\"Marked bad\"><span class=\"icon\">⚠️</span></span></span></div>"`
+      `"<div class=\"nurse-pill\" data-type=\"other\" data-role=\"nurse\" tabindex=\"0\" aria-label=\"Alice, other nurse, on break, has student, has comment, marked bad\"><span class=\"nurse-name\">Alice</span><span class=\"chips\"><span class=\"chip\" aria-label=\"On break\"><span class=\"icon\">⏸️</span></span><span class=\"chip\" aria-label=\"Has student\"><span class=\"icon\">🎓</span></span><span class=\"chip\" aria-label=\"Has comment\"><span class=\"icon\">💬</span></span><span class=\"chip\" aria-label=\"Marked bad\"><span class=\"icon\">⚠️</span></span></span></div>"`
     );
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,
+    "resolveJsonModule": true,
     "types": ["vitest", "node"]
   }
 }


### PR DESCRIPTION
## Summary
- prevent clock and widget ticks from re-rendering forms
- normalize staff roles/IDs and add default seeding via JSON
- add DTO action with 60m offgoing retention

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68addac357488327b288baad6a384afc