### PR TITLE
refactor: modern card layout for main board

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -30,6 +30,16 @@
   --z-modal: 1000;
   --z-toast: 1100;
   --z-drag: 1200;
+
+  --zone-fg: #0a0a0a;
+  --card-border: rgba(0,0,0,.08);
+  --shadow: 0 1px 2px rgba(0,0,0,.06), 0 8px 24px rgba(0,0,0,.06);
+  --ring: rgba(0,120,212,.45);
+
+  --zone-bg-1:#f2f7ff; --zone-bg-2:#f6fff2; --zone-bg-3:#fff7f2;
+  --zone-bg-4:#f7f2ff; --zone-bg-5:#f2fffb; --zone-bg-6:#fff2f7; --zone-bg-7:#f9f9f9;
+  --nurse-bg-1:#e7f0ff; --nurse-bg-2:#ecffe7; --nurse-bg-3:#ffece7;
+  --nurse-bg-4:#ece7ff; --nurse-bg-5:#e7fff8; --nurse-bg-6:#ffe7f0; --nurse-bg-7:#ededed;
 }
 
 :root[data-theme='light']{
@@ -61,13 +71,12 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .clock-big{font-size:var(--f-xl);font-weight:700;line-height:1}
 .date-small{font-size:var(--f);color:var(--text-muted)}
 .actions{display:flex;gap:var(--gap);align-items:center}
-.layout{display:grid;grid-template-columns:1.6fr 1fr;gap:var(--gap)}
+.layout{display:grid;grid-template-columns:1fr clamp(280px,25vw,320px);gap:var(--gap)}
 .panel{background:var(--panel);color:var(--text-high);border:1px solid var(--line);border-radius:var(--radius);padding:12px 14px;box-shadow:var(--elev-1)}
 .panel h3{color:var(--text-high);font-size:clamp(14px,.95vw,16px)}
 .panel .muted{color:var(--text-muted)}
-.zones-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:10px}
-@media (max-width:1200px){.zones-grid{grid-template-columns:repeat(3,1fr);}}
-@media (max-width:900px){.layout{grid-template-columns:1fr}.zones-grid{grid-template-columns:repeat(2,1fr);}}
+.zones-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:clamp(8px,1.5vw,12px);max-width:1520px;margin:0 auto}
+@media (max-width:900px){.layout{grid-template-columns:1fr}.zones-grid{grid-template-columns:1fr}}
 
 .widget{background:color-mix(in oklab,var(--control) 96%, black 4%);border:1px dashed var(--line);border-radius:12px;padding:8px 10px;margin-top:8px}
 .widget .title{font-weight:600;color:var(--text-high);display:flex;align-items:center;gap:6px}
@@ -101,7 +110,10 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 
 .nurse-pill:focus-visible,.chip:focus-visible{outline:2px solid color-mix(in oklab,currentColor 60%,white 0%);outline-offset:2px}
 
-@media print{#widgets,.widget{display:none!important}}
+@media print{
+  #widgets,.widget{display:none!important}
+  .zone-card,.nurse-card{background:#fff!important;color:#000!important;box-shadow:none!important}
+}
 
 .overlay,.backdrop,.modal-backdrop{position:fixed;inset:0;z-index:var(--z-modal)}
 .overlay:not(.open),.backdrop:not(.open),.modal-backdrop:not(.open){pointer-events:none;opacity:0}

--- a/src/ui/mainBoard/boardLayout.css
+++ b/src/ui/mainBoard/boardLayout.css
@@ -1,0 +1,11 @@
+.zone-card{background:var(--zone-bg,var(--zone-bg-1));color:var(--zone-fg);border:1px solid var(--card-border);border-radius:16px;padding:16px;box-shadow:var(--shadow);}
+.zone-card__title{font-weight:700;font-size:clamp(1.25rem,1.2rem + 0.4vw,1.5rem);margin:0 0 12px 0;letter-spacing:-.2px;}
+.zone-card__body{display:flex;flex-direction:column;gap:10px;overflow-y:auto;}
+.nurse-row{display:flex;align-items:center;gap:8px;}
+.nurse-card{background:var(--nurse-bg,var(--nurse-bg-2));border:1px solid var(--card-border);border-radius:14px;padding:12px 14px;box-shadow:var(--shadow);flex:1;display:flex;align-items:center;gap:8px;}
+.nurse-card__text{display:flex;flex-direction:column;min-width:0;}
+.nurse-row .btn{flex-shrink:0;}
+.nurse-card__name{font-weight:600;font-size:clamp(1.05rem,1rem + 0.3vw,1.25rem);line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.nurse-card__meta{color:var(--text-med);font-size:.85em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.nurse-card:focus-visible{outline:2px solid var(--ring);outline-offset:2px;}
+

--- a/src/ui/mainTab.ts
+++ b/src/ui/mainTab.ts
@@ -2,6 +2,7 @@ import { DB, KS, getConfig, STATE, loadStaff, saveStaff, Staff } from '@/state';
 import { setNurseCache, labelFromId } from '@/utils/names';
 import { renderWidgets } from './widgets';
 import { nurseTile } from './nurseTile';
+import './mainBoard/boardLayout.css';
 import { startBreak, endBreak, moveSlot, type Slot } from '@/slots';
 import { canonNurseType } from '@/domain/lexicon';
 
@@ -34,7 +35,7 @@ export async function renderMain(
     if (!active) active = buildEmptyActive(ctx.dateISO, ctx.shift, cfg.zones || []);
 
     root.innerHTML = `
-    <div class="layout">
+    <div class="layout" data-testid="main-board">
       <div class="col col-left">
         <section class="panel">
           <h3>Leadership</h3>
@@ -133,27 +134,35 @@ function renderLeadership(active: any) {
 function renderZones(active: any, cfg: any, staff: Staff[], save: () => void) {
   const cont = document.getElementById('zones')!;
   cont.innerHTML = '';
-  for (const z of cfg.zones || []) {
-    const div = document.createElement('div');
-    const h = document.createElement('h4');
-    h.textContent = z;
-    div.appendChild(h);
-    const list = document.createElement('div');
+  (cfg.zones || []).forEach((z: string, i: number) => {
+    const section = document.createElement('section');
+    section.className = 'zone-card';
+    section.setAttribute('data-testid', 'zone-card');
+    const zi = (i % 7) + 1;
+    const ni = ((i + 1) % 7) + 1;
+    section.style.setProperty('--zone-bg', `var(--zone-bg-${zi})`);
+    section.style.setProperty('--nurse-bg', `var(--nurse-bg-${ni})`);
+
+    const title = document.createElement('h2');
+    title.className = 'zone-card__title';
+    title.textContent = z;
+    section.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'zone-card__body';
 
     (active.zones[z] || []).forEach((s: Slot, idx: number) => {
-      const item = document.createElement('div');
+      const row = document.createElement('div');
+      row.className = 'nurse-row';
       const st = staff.find((n) => n.id === s.nurseId);
       const tileWrapper = document.createElement('div');
-
-      // Ensure nurseTile gets a consistent role/type shape
       tileWrapper.innerHTML = nurseTile(s, {
         id: st?.id || s.nurseId,
         name: st?.name,
         role: st?.role || 'nurse',
         type: st?.type || 'other',
       } as Staff);
-
-      item.appendChild(tileWrapper.firstElementChild!);
+      row.appendChild(tileWrapper.firstElementChild!);
 
       const btn = document.createElement('button');
       btn.textContent = 'Manage';
@@ -171,13 +180,13 @@ function renderZones(active: any, cfg: any, staff: Staff[], save: () => void) {
           cfg
         )
       );
-      item.appendChild(btn);
-      list.appendChild(item);
+      row.appendChild(btn);
+      body.appendChild(row);
     });
 
-    div.appendChild(list);
-    cont.appendChild(div);
-  }
+    section.appendChild(body);
+    cont.appendChild(section);
+  });
 }
 
 function wireComments(active: any, save: () => void) {

--- a/src/ui/nurseTile.ts
+++ b/src/ui/nurseTile.ts
@@ -22,15 +22,14 @@ export function nurseTile(slot: Slot, staff: Staff): string {
     );
 
   const name = formatShortName(staff.name);
+  const meta = `${staff.type} ${staff.role}`;
   const statuses: string[] = [];
   if (slot.break?.active) statuses.push('on break');
   if (slot.student) statuses.push('has student');
   if (slot.comment) statuses.push('has comment');
   if (slot.bad) statuses.push('marked bad');
-  const aria = `${name}, ${staff.type} ${staff.role}${
-    statuses.length ? ', ' + statuses.join(', ') : ''
-  }`;
+  const aria = `${name}, ${meta}${statuses.length ? ', ' + statuses.join(', ') : ''}`;
   const chipStr = chips.length ? `<span class="chips">${chips.join('')}</span>` : '';
-  return `<div class="nurse-pill" data-type="${staff.type}" data-role="${staff.role}" tabindex="0" aria-label="${aria}"><span class="nurse-name">${name}</span>${chipStr}</div>`;
+  return `<div class="nurse-card" data-type="${staff.type}" data-role="${staff.role}" tabindex="0" aria-label="${aria}"><div class="nurse-card__text"><div class="nurse-card__name">${name}</div><div class="nurse-card__meta">${meta}</div></div>${chipStr}</div>`;
 }
 

--- a/tests/names.spec.ts
+++ b/tests/names.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { formatShortName } from '@/utils/names';
+
+describe('formatShortName', () => {
+  it('shows first name when no last provided', () => {
+    expect(formatShortName('Alice')).toBe('Alice');
+  });
+  it('shows last initial', () => {
+    expect(formatShortName('Alice Baker')).toBe('Alice B.');
+  });
+});

--- a/tests/slots.spec.ts
+++ b/tests/slots.spec.ts
@@ -7,7 +7,7 @@ import {
   type Board,
 } from "../src/slots";
 import { isEmployeeIdUnique } from "../src/utils/staff";
-import { nurseTile as renderTile } from "../src/ui/nurseTile";
+import { nurseTile as renderTile } from "@/ui/nurseTile";
 
 describe("ensureUniqueAssignment", () => {
   it("removes duplicates across board", () => {
@@ -77,7 +77,7 @@ describe("nurse tile snapshot", () => {
       type: "other",
     });
     expect(html).toMatchInlineSnapshot(
-      `"<div class=\"nurse-pill\" data-type=\"other\" data-role=\"nurse\" tabindex=\"0\" aria-label=\"Alice, other nurse, on break, has student, has comment, marked bad\"><span class=\"nurse-name\">Alice</span><span class=\"chips\"><span class=\"chip\" aria-label=\"On break\"><span class=\"icon\">⏸️</span></span><span class=\"chip\" aria-label=\"Has student\"><span class=\"icon\">🎓</span></span><span class=\"chip\" aria-label=\"Has comment\"><span class=\"icon\">💬</span></span><span class=\"chip\" aria-label=\"Marked bad\"><span class=\"icon\">⚠️</span></span></span></div>"`
+      `"<div class=\"nurse-card\" data-type=\"other\" data-role=\"nurse\" tabindex=\"0\" aria-label=\"Alice, other nurse, on break, has student, has comment, marked bad\"><div class=\"nurse-card__text\"><div class=\"nurse-card__name\">Alice</div><div class=\"nurse-card__meta\">other nurse</div></div><span class=\"chips\"><span class=\"chip\" aria-label=\"On break\"><span class=\"icon\">⏸️</span></span><span class=\"chip\" aria-label=\"Has student\"><span class=\"icon\">🎓</span></span><span class=\"chip\" aria-label=\"Has comment\"><span class=\"icon\">💬</span></span><span class=\"chip\" aria-label=\"Marked bad\"><span class=\"icon\">⚠️</span></span></span></div>"`
     );
   });
 });


### PR DESCRIPTION
## Summary
- refresh main board with stacked zone and nurse cards for improved legibility
- add responsive grid and narrower side panel for better use of space
- cover name formatter with unit tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ade12d2ba88327bb628dd9623dabd4