### PR TITLE
Fix template string closure in main board render

### DIFF
--- a/src/ui/mainTab.ts
+++ b/src/ui/mainTab.ts
@@ -102,7 +102,7 @@ export async function renderMain(
           </section>
         </div>
       </div>
-    ";
+    `;
 
     // Debounced save
     let saveTimer: any;


### PR DESCRIPTION
## Summary
- correct closing backtick for main board HTML template in `mainTab`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adf0ab463c832785e9f8d8004327fe