### PR TITLE
style: refine zone card highlight

### DIFF
--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -21,18 +21,6 @@ import { startBreak, endBreak, moveSlot, type Slot } from '@/slots';
 import { canonNurseType } from '@/domain/lexicon';
 import { normalizeZones, normalizeActiveZones, type ZoneDef } from '@/utils/zones';
 
-// Palette used to pair zone background with a readable nurse tile bg in dark mode
-const PALETTE: [string, string][] = [
-  ['#3b82f6', '#60a5fa'],
-  ['#2563eb', '#3b82f6'],
-  ['#1d4ed8', '#2563eb'],
-  ['#ef4444', '#f87171'],
-  ['#b91c1c', '#ef4444'],
-  ['#10b981', '#34d399'],
-  ['#047857', '#10b981'],
-  ['#8b5cf6', '#a78bfa'],
-];
-
 // --- helpers ---------------------------------------------------------------
 
 function buildEmptyActive(
@@ -207,19 +195,13 @@ function renderZones(active: ActiveBoard, cfg: any, staff: Staff[], save: () => 
     section.className = 'zone-card';
     section.setAttribute('data-testid', 'zone-card');
 
-    // Color: explicit or palette variables
+    // Highlight color: explicit or from palette
     const explicit = z.color || cfg.zoneColors?.[zName];
     if (explicit) {
-      section.style.background = explicit;
-      // If explicit color matches our palette's first color, use its paired nurse tile color
-      const match = PALETTE.find(([zone]) => zone.toLowerCase() === String(explicit).toLowerCase());
-      if (match) section.style.setProperty('--nurse-bg', match[1]);
+      section.style.setProperty('--zone-color', explicit);
     } else {
-      // Fall back to CSS var palette; using 8 to match PALETTE length
       const zi = (i % 8) + 1;
-      const ni = ((i + 1) % 8) + 1;
-      section.style.setProperty('--zone-bg', `var(--zone-bg-${zi})`);
-      section.style.setProperty('--nurse-bg', `var(--nurse-bg-${ni})`);
+      section.style.setProperty('--zone-color', `var(--zone-bg-${zi})`);
     }
 
     const title = document.createElement('h2');

--- a/src/ui/mainBoard/boardLayout.css
+++ b/src/ui/mainBoard/boardLayout.css
@@ -1,8 +1,9 @@
-.zone-card{background:var(--zone-bg,var(--zone-bg-1));color:var(--zone-fg);border:1px solid var(--card-border);border-radius:16px;padding:16px;box-shadow:var(--shadow);}
+.zone-card{position:relative;background:var(--panel);color:var(--text-high);border:1px solid var(--card-border);border-radius:16px;padding:16px;box-shadow:var(--shadow);}
+.zone-card::before{content:"";position:absolute;top:0;left:0;right:0;height:6px;background:var(--zone-color,var(--zone-bg-1));border-top-left-radius:16px;border-top-right-radius:16px;}
 .zone-card__title{font-weight:700;font-size:clamp(1.25rem,1.2rem + 0.4vw,1.5rem);margin:0 0 12px 0;letter-spacing:-.2px;}
 .zone-card__body{display:flex;flex-direction:column;gap:10px;overflow-y:auto;}
 .nurse-row{display:flex;align-items:center;gap:8px;}
-.nurse-card{background:var(--nurse-bg,var(--nurse-bg-2));border:1px solid var(--card-border);border-radius:14px;padding:12px 14px;box-shadow:var(--shadow);flex:1;display:flex;align-items:center;gap:8px;}
+.nurse-card{background:var(--control);border:1px solid var(--card-border);border-radius:14px;padding:12px 14px;box-shadow:var(--shadow);flex:1;display:flex;align-items:center;gap:8px;}
 .nurse-card__text{display:flex;flex-direction:column;min-width:0;}
 .nurse-row .btn{flex-shrink:0;}
 .nurse-card__name{font-weight:600;font-size:clamp(1.05rem,1rem + 0.3vw,1.25rem);line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}


### PR DESCRIPTION
## Summary
- show zone color as thin top bar instead of full background
- use neutral background for nurse cards

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af07c7c52c8327b18c5a46605893e6