### PR TITLE
Adjust builder layout for wider schedule

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -92,6 +92,7 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 
 /* choose the variable-based sidebar width */
 .layout{display:grid;grid-template-columns:1fr var(--right-sidebar-w);gap:var(--gap)}
+.builder-layout{grid-template-columns:minmax(200px,25%) 1fr}
 
 .panel{background:var(--panel);color:var(--text-high);border:1px solid var(--line);border-radius:var(--radius);padding:12px 14px;box-shadow:var(--elev-1)}
 .panel h3{color:var(--text-high);font-size:clamp(14px,.95vw,16px)}

--- a/src/ui/builder.ts
+++ b/src/ui/builder.ts
@@ -35,7 +35,7 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
   }
 
   root.innerHTML = `
-    <div class="layout" data-testid="builder">
+    <div class="layout builder-layout" data-testid="builder">
       <div class="col col-left">
         <section class="panel">
           <h3>Roster</h3>


### PR DESCRIPTION
## Summary
- Limit builder roster column to at most 25% width
- Expand draft schedule area for better usability

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af0bfa62d08327b76a8c1f1ea9d50b