### PR TITLE
feat(builder): support zone editing and drag

### DIFF
--- a/src/ui/builder.ts
+++ b/src/ui/builder.ts
@@ -1,4 +1,15 @@
-import { STATE, getConfig, loadStaff, KS, DB, type DraftShift, type Staff, CURRENT_SCHEMA_VERSION, applyDraftToActive } from '@/state';
+import {
+  STATE,
+  getConfig,
+  loadStaff,
+  KS,
+  DB,
+  type DraftShift,
+  type Staff,
+  CURRENT_SCHEMA_VERSION,
+  applyDraftToActive,
+  saveConfig,
+} from '@/state';
 import { upsertSlot, type Slot } from '@/slots';
 import { nurseTile } from './nurseTile';
 import { normalizeActiveZones, type ZoneDef } from '@/utils/zones';
@@ -74,19 +85,100 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
   function renderZones() {
     const cont = document.getElementById('builder-zones')!;
     cont.innerHTML = '';
-    cfg.zones.forEach((z) => {
+    cfg.zones.forEach((z, i) => {
       const section = document.createElement('section');
       section.className = 'zone-card';
+      section.draggable = true;
+      section.dataset.index = String(i);
+      section.addEventListener('dragstart', (e) => {
+        const ev = e as DragEvent;
+        ev.dataTransfer?.setData('zone-index', String(i));
+      });
+      section.addEventListener('dragover', (e) => e.preventDefault());
+      section.addEventListener('drop', async (e) => {
+        e.preventDefault();
+        const ev = e as DragEvent;
+        const fromIdx = Number(ev.dataTransfer?.getData('zone-index'));
+        if (!isNaN(fromIdx) && fromIdx !== i) {
+          const [moved] = cfg.zones.splice(fromIdx, 1);
+          cfg.zones.splice(i, 0, moved);
+          board.zones = Object.fromEntries(
+            cfg.zones.map((zz) => [zz.name, board.zones[zz.name] || []])
+          );
+          await saveConfig({ zones: cfg.zones });
+          await save();
+          renderZones();
+          return;
+        }
+      });
+
       const title = document.createElement('h2');
       title.className = 'zone-card__title';
       title.textContent = z.name;
       section.appendChild(title);
 
+      const actions = document.createElement('div');
+      actions.className = 'zone-card__actions';
+
+      const editBtn = document.createElement('button');
+      editBtn.textContent = 'Edit';
+      editBtn.className = 'btn';
+      editBtn.addEventListener('click', async () => {
+        const val = prompt('Rename zone', z.name)?.trim();
+        if (val && val !== z.name) {
+          const idx = cfg.zones.findIndex((zz) => zz.name === z.name);
+          cfg.zones[idx].name = val;
+          if (cfg.zoneColors && cfg.zoneColors[z.name]) {
+            cfg.zoneColors[val] = cfg.zoneColors[z.name];
+            delete cfg.zoneColors[z.name];
+          }
+          board.zones[val] = board.zones[z.name] || [];
+          delete board.zones[z.name];
+          await saveConfig({ zones: cfg.zones, zoneColors: cfg.zoneColors });
+          await save();
+          renderZones();
+        }
+      });
+      actions.appendChild(editBtn);
+
+      const delBtn = document.createElement('button');
+      delBtn.textContent = 'Delete';
+      delBtn.className = 'btn';
+      delBtn.addEventListener('click', async () => {
+        if (!confirm(`Delete zone ${z.name}?`)) return;
+        const idx = cfg.zones.findIndex((zz) => zz.name === z.name);
+        const removed = cfg.zones.splice(idx, 1)[0];
+        if (removed) {
+          delete board.zones[removed.name];
+          if (cfg.zoneColors) delete cfg.zoneColors[removed.name];
+        }
+        await saveConfig({ zones: cfg.zones, zoneColors: cfg.zoneColors });
+        await save();
+        renderZones();
+      });
+      actions.appendChild(delBtn);
+
+      section.appendChild(actions);
+
       const body = document.createElement('div');
       body.className = 'zone-card__body';
-      body.addEventListener('dragover', (e) => e.preventDefault());
+      body.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      });
       body.addEventListener('drop', async (e: DragEvent) => {
         e.preventDefault();
+        e.stopPropagation();
+        const slotData = e.dataTransfer?.getData('slot');
+        if (slotData) {
+          const { zone: fromZone, index } = JSON.parse(slotData);
+          const [slot] = board.zones[fromZone].splice(index, 1);
+          const arr = board.zones[z.name] || (board.zones[z.name] = []);
+          arr.push(slot);
+          await save();
+          renderZones();
+          return;
+        }
         const id = e.dataTransfer?.getData('text/plain');
         if (id) {
           upsertSlot(board, { zone: z.name }, { nurseId: id });
@@ -100,6 +192,11 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
         if (!st) return;
         const row = document.createElement('div');
         row.className = 'nurse-row';
+        row.draggable = true;
+        row.addEventListener('dragstart', (e) => {
+          const ev = e as DragEvent;
+          ev.dataTransfer?.setData('slot', JSON.stringify({ zone: z.name, index: idx }));
+        });
 
         const tile = document.createElement('div');
         tile.innerHTML = nurseTile(slot, st);

--- a/src/ui/mainBoard/boardLayout.css
+++ b/src/ui/mainBoard/boardLayout.css
@@ -1,6 +1,7 @@
 .zone-card{position:relative;background:var(--panel);color:var(--text-high);border:1px solid var(--card-border);border-radius:16px;padding:16px;box-shadow:var(--shadow);}
 .zone-card::before{content:"";position:absolute;top:0;left:0;right:0;height:6px;background:var(--zone-color,var(--zone-bg-1));border-top-left-radius:16px;border-top-right-radius:16px;}
 .zone-card__title{font-weight:700;font-size:clamp(1.25rem,1.2rem + 0.4vw,1.5rem);margin:0 0 12px 0;letter-spacing:-.2px;}
+.zone-card__actions{display:flex;gap:8px;margin-bottom:12px;}
 .zone-card__body{display:flex;flex-direction:column;gap:10px;overflow-y:auto;}
 .nurse-row{display:flex;align-items:center;gap:8px;}
 .nurse-card{background:var(--control);border:1px solid var(--card-border);border-radius:14px;padding:12px 14px;box-shadow:var(--shadow);flex:1;display:flex;align-items:center;gap:8px;}


### PR DESCRIPTION
## Summary
- allow dragging nurses between zones and from the roster
- make zones draggable with rename and delete actions
- style zone card actions row for builder UI

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af0dfc36948327a72de9d8541d661a