### PR TITLE
Fix builder roster drag-and-drop issues

### DIFF
--- a/src/ui/builder.ts
+++ b/src/ui/builder.ts
@@ -152,25 +152,6 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
         ev.dataTransfer?.setData('zone-index', String(i));
       });
       section.addEventListener('dragover', (e) => e.preventDefault());
-      section.addEventListener('drop', async (e) => {
-        e.preventDefault();
-        const ev = e as DragEvent;
-        const fromIdxStr = ev.dataTransfer?.getData('zone-index');
-        if (fromIdxStr) {
-          const fromIdx = Number(fromIdxStr);
-          if (!isNaN(fromIdx) && fromIdx !== i) {
-            const [moved] = cfg.zones.splice(fromIdx, 1);
-            cfg.zones.splice(i, 0, moved);
-            board.zones = Object.fromEntries(
-              cfg.zones.map((zz) => [zz.name, board.zones[zz.name] || []])
-            );
-            await saveConfig({ zones: cfg.zones });
-            await save();
-            renderZones();
-            return;
-          }
-        }
-      });
 
       const title = document.createElement('h2');
       title.className = 'zone-card__title';
@@ -226,7 +207,8 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
         e.preventDefault();
         e.stopPropagation();
       });
-      body.addEventListener('drop', async (e: DragEvent) => {
+
+      const onDrop = async (e: DragEvent) => {
         e.preventDefault();
         e.stopPropagation();
         const zoneIdxStr = e.dataTransfer?.getData('zone-index');
@@ -262,7 +244,10 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
           await save();
           renderZones();
         }
-      });
+      };
+
+      section.addEventListener('drop', onDrop);
+      body.addEventListener('drop', onDrop);
 
       (board.zones[z.name] || []).forEach((slot, idx) => {
         const st = staff.find((n) => n.id === slot.nurseId);

--- a/src/ui/mainBoard/boardLayout.css
+++ b/src/ui/mainBoard/boardLayout.css
@@ -2,7 +2,8 @@
 .zone-card::before{content:"";position:absolute;top:0;left:0;right:0;height:6px;background:var(--zone-color,var(--zone-bg-1));border-top-left-radius:16px;border-top-right-radius:16px;}
 .zone-card__title{font-weight:700;font-size:clamp(1.25rem,1.2rem + 0.4vw,1.5rem);margin:0 0 12px 0;letter-spacing:-.2px;}
 .zone-card__actions{display:flex;gap:8px;margin-bottom:12px;}
-.zone-card__body{display:flex;flex-direction:column;gap:10px;overflow-y:auto;}
+.zone-card__body{display:flex;flex-direction:column;gap:10px;overflow-y:auto;min-height:60px;padding:10px;}
+.zone-card__body:empty{border:2px dashed var(--card-border);border-radius:8px;}
 .nurse-row{display:flex;align-items:center;gap:8px;}
 .nurse-card{background:var(--control);border:1px solid var(--card-border);border-radius:14px;padding:12px 14px;box-shadow:var(--shadow);flex:1;display:flex;align-items:center;gap:8px;}
 .nurse-card__text{display:flex;flex-direction:column;min-width:0;}


### PR DESCRIPTION
## Summary
- ensure zone cards accept roster drops by handling drop events on both section and body
- show empty zone drop targets with minimum height and dashed border

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af1493eb9483278a0f8a7da689d540