### PR TITLE
feat: improve leadership logging and huddle checklist

### DIFF
--- a/src/config/huddle.ts
+++ b/src/config/huddle.ts
@@ -1,0 +1,24 @@
+export interface HuddleItem {
+  id: string;
+  label: string;
+  section: string;
+  required?: boolean;
+}
+
+export const DEFAULT_HUDDLE_ITEMS: HuddleItem[] = [
+  { id: 'staffing_ok', label: 'Staffing adequate', section: 'Staffing & Assignments', required: true },
+  { id: 'relief_plan', label: 'Relief/break coverage set', section: 'Staffing & Assignments' },
+  { id: 'bed_flow', label: 'Admit bed flow aligned', section: 'Throughput & Beds' },
+  { id: 'ems_status', label: 'EMS/diversion status reviewed', section: 'Throughput & Beds' },
+  { id: 'ops_status', label: 'Imaging/Lab/IT status good', section: 'Operational Status' },
+  { id: 'psych_sitter', label: 'Psych/sitter coverage', section: 'Operational Status' },
+  { id: 'code_ready', label: 'Code/airway/blood ready', section: 'Safety & Equipment', required: true },
+  { id: 'isolation_ok', label: 'Isolation/neg pressure OK', section: 'Safety & Equipment' },
+  { id: 'stroke_ready', label: 'Stroke/TNK pathway ready', section: 'Time-Critical Protocols' },
+  { id: 'stemi_ready', label: 'STEMI/PCI pathway ready', section: 'Time-Critical Protocols' },
+  { id: 'sepsis_watch', label: 'Sepsis bundle watchouts', section: 'Time-Critical Protocols' },
+  { id: 'trauma_plan', label: 'Trauma activation plan', section: 'Time-Critical Protocols' },
+  { id: 'roles_named', label: 'Roles named (Charge/Triage/Code)', section: 'Comms & Escalation', required: true },
+  { id: 'escalation_ok', label: 'Escalation path confirmed', section: 'Comms & Escalation' },
+  { id: 'announcements', label: 'Announcements covered', section: 'Comms & Escalation' },
+];

--- a/src/history/NurseHistory.ts
+++ b/src/history/NurseHistory.ts
@@ -2,6 +2,6 @@ import './history.css';
 
 /** Render the nurse-centric history search view. */
 export function renderNurseHistory(root: HTMLElement): void {
-  root.innerHTML = '<div class="history-nurse"><p class="muted">Nurse history view coming soon.</p></div>';
+  root.innerHTML = '<div class="history-nurse"><p class="muted">Will display when available.</p></div>';
 }
 

--- a/src/state/history.ts
+++ b/src/state/history.ts
@@ -50,7 +50,10 @@ export interface Assignment {
 export interface HuddleChecklistItem {
   id: string;
   label: string;
-  checked: boolean;
+  section: string;
+  required?: boolean;
+  state: 'ok' | 'issue' | 'na';
+  note?: string;
 }
 
 export interface HuddleRecord {

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -346,6 +346,41 @@ export async function applyDraftToActive(
       });
     }
   }
+
+  const now = new Date().toISOString();
+  if (draft.charge?.nurseId) {
+    const info = staffMap[draft.charge.nurseId];
+    assignments.push({
+      staffId: draft.charge.nurseId,
+      displayName: info?.name || draft.charge.nurseId,
+      role: info?.role || 'nurse',
+      zone: 'Charge',
+      startISO: now,
+      endISO: now,
+    });
+  }
+  if (draft.triage?.nurseId) {
+    const info = staffMap[draft.triage.nurseId];
+    assignments.push({
+      staffId: draft.triage.nurseId,
+      displayName: info?.name || draft.triage.nurseId,
+      role: info?.role || 'nurse',
+      zone: 'Triage',
+      startISO: now,
+      endISO: now,
+    });
+  }
+  if (draft.admin?.nurseId) {
+    const info = staffMap[draft.admin.nurseId];
+    assignments.push({
+      staffId: draft.admin.nurseId,
+      displayName: info?.name || draft.admin.nurseId,
+      role: info?.role || 'nurse',
+      zone: 'Secretary',
+      startISO: now,
+      endISO: now,
+    });
+  }
   const huddle = await getHuddle(dateISO, shift as ShiftKind);
   const snapshot: PublishedShiftSnapshot = {
     version: 1,

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -88,7 +88,7 @@ export async function renderBoard(
           </section>
 
           <section class="panel">
-            <h3>Assignments (TV Landscape)</h3>
+            <h3>Assignments</h3>
             <div id="zones" class="zones-grid"></div>
           </section>
 

--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -35,7 +35,9 @@ export function renderHeader() {
     </div>
   `;
   if (mode === 'shiftHuddle')
-    document.getElementById('huddle-btn')?.addEventListener('click', openHuddle);
+    document.getElementById('huddle-btn')?.addEventListener('click', () =>
+      openHuddle(STATE.dateISO, shift)
+    );
   else if (mode === 'legacySignout')
     document.getElementById('handoff')?.addEventListener('click', manualHandoff);
   document.getElementById('theme-toggle')!.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- track charge, triage, and secretary assignments in shift history
- remove "(TV Landscape)" from board assignments header
- add structured huddle checklist with tri-state items and auto-save
- tweak nurse history placeholder text

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afba712f50832783e2a5362e627fef