### PR TITLE
feat: allow dragging zones to patient care team area

### DIFF
--- a/src/ui/builder.ts
+++ b/src/ui/builder.ts
@@ -64,6 +64,7 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
             <div id="builder-triage"></div>
             <div id="builder-secretary"></div>
           </div>
+          <div id="builder-pct-zones" class="zones-grid"></div>
         </section>
         <section class="panel">
           <h3>Pending Zones</h3>
@@ -220,7 +221,9 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
   }
 
   function renderZones() {
+    const pctCont = document.getElementById('builder-pct-zones')!;
     const cont = document.getElementById('builder-zones')!;
+    pctCont.innerHTML = '';
     cont.innerHTML = '';
     cfg.zones.forEach((z, i) => {
       const section = document.createElement('section');
@@ -366,8 +369,28 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
       });
 
       section.appendChild(body);
-      cont.appendChild(section);
+      (z.pct ? pctCont : cont).appendChild(section);
     });
+
+    const enableDrop = (container: HTMLElement, pct: boolean) => {
+      container.addEventListener('dragover', (e) => e.preventDefault());
+      container.addEventListener('drop', async (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const zoneIdxStr = e.dataTransfer?.getData('zone-index');
+        if (zoneIdxStr) {
+          const fromIdx = Number(zoneIdxStr);
+          if (!isNaN(fromIdx)) {
+            cfg.zones[fromIdx].pct = pct;
+            await saveConfig({ zones: cfg.zones });
+            renderZones();
+          }
+        }
+      });
+    };
+
+    enableDrop(pctCont, true);
+    enableDrop(cont, false);
   }
 
   document.getElementById('builder-save')!.addEventListener('click', save);

--- a/src/utils/zones.ts
+++ b/src/utils/zones.ts
@@ -2,6 +2,8 @@ export interface ZoneDef {
   id: string;
   name: string;
   color?: string;
+  /** Whether the zone is part of the patient care team area. */
+  pct?: boolean;
 }
 
 /**
@@ -16,20 +18,23 @@ export function normalizeZones(input: any[]): ZoneDef[] {
       return {
         id: z.toLowerCase().replace(/\s+/g, '_'),
         name: z,
-        color: '#ffffff'
+        color: '#ffffff',
+        pct: false,
       };
     } else if (typeof z === 'object' && z !== null) {
       const name = z.name ?? String(z.id ?? `Zone ${i + 1}`);
       return {
         id: (z.id ?? name).toLowerCase().replace(/\s+/g, '_'),
         name,
-        color: z.color ?? '#ffffff'
+        color: z.color ?? '#ffffff',
+        pct: !!(z as any).pct,
       };
     } else {
       return {
         id: `zone_${i}`,
         name: `Zone ${i + 1}`,
-        color: '#ffffff'
+        color: '#ffffff',
+        pct: false,
       };
     }
   });


### PR DESCRIPTION
## Summary
- allow dragging zone cards into the Patient Care Team section
- add `pct` flag to zone definition and persist group changes
- update builder to support separating zones between team and assignments

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afbc1cc1b0832789df84239784375c