### PR TITLE
feat(server): add PHP JSON API + front-end adapter for shared board state

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,15 +1,40 @@
-# Serve index by default
+# Serve index.html as default (fallback to SPA-style)
 DirectoryIndex index.html index.php
 
-# Correct MIME for JSON/JS/CSS
-AddType application/json .json
-AddType application/javascript .js
-AddType text/css .css
-
-# Single Page App rewrite (preserve real files/dirs)
+# Deny direct access to data directory if it sits inside webroot
 RewriteEngine On
-RewriteBase /
-RewriteCond %{REQUEST_FILENAME} -f [OR]
-RewriteCond %{REQUEST_FILENAME} -d
-RewriteRule ^ - [L]
-RewriteRule . /index.html [L]
+RewriteRule ^data/ - [F,L]
+
+# Route pretty API path /api/* to api.php
+RewriteCond %{REQUEST_URI} ^/api($|/)
+RewriteRule ^api/?(.*)$ api.php [QSA,L]
+
+# JSON, CORS, and security headers
+<IfModule mod_headers.c>
+  Header always set X-Frame-Options "SAMEORIGIN"
+  Header always set X-Content-Type-Options "nosniff"
+  Header always set Referrer-Policy "no-referrer-when-downgrade"
+  Header always set Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https: http:; img-src * data: blob:; connect-src *"
+  Header always set Access-Control-Allow-Credentials "true"
+</IfModule>
+
+# Gzip/Brotli if available
+<IfModule mod_deflate.c>
+  AddOutputFilterByType DEFLATE text/html text/css application/javascript application/json
+</IfModule>
+
+# Cache static assets
+<IfModule mod_expires.c>
+  ExpiresActive On
+  ExpiresByType text/html "access plus 5m"
+  ExpiresByType text/css "access plus 7d"
+  ExpiresByType application/javascript "access plus 7d"
+  ExpiresByType image/svg+xml "access plus 30d"
+  ExpiresByType image/png "access plus 30d"
+  ExpiresByType image/jpeg "access plus 30d"
+  ExpiresByType application/json "access plus 0s"
+</IfModule>
+
+# Optional (set server-side secrets) – replace values or set in cPanel
+# SetEnv HEYBRE_API_KEY "REPLACE_WITH_RANDOM_LONG_STRING"
+# SetEnv HEYBRE_DATA_DIR "/home/<cpanel-user>/heybre-board-data"

--- a/README.md
+++ b/README.md
@@ -62,3 +62,19 @@ zone Alpha.
 - “pending” → draft
 - “traveler/contract” → travel
 - UK spellings (colour/favour/organise/cancelled) → US spelling
+
+## PHP API deployment
+
+- Requires **PHP ≥ 8.0**.
+- Set environment variables in cPanel or `.htaccess`:
+
+```apache
+SetEnv HEYBRE_API_KEY "REPLACE_WITH_RANDOM_LONG_STRING"
+# Recommended: store JSON outside webroot
+SetEnv HEYBRE_DATA_DIR "/home/<cpanel-user>/heybre-board-data"
+```
+
+- Make sure the data path is writable by PHP.
+- Validate with:
+  - `GET https://board.heybre.com/api.php?res=staff`
+  - Save something from the UI and confirm `active-YYYY-MM-DD-<shift>.json` appears in the data dir.

--- a/api.php
+++ b/api.php
@@ -1,0 +1,262 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Minimal JSON file-based API for Board.HeyBre.com
+ * Storage: ./data/*.json (or move outside webroot and set DATA_DIR).
+ *
+ * Security:
+ * - Set an env var HEYBRE_API_KEY in .htaccess or panel, and send it as "X-API-Key" header.
+ * - Alternatively, set BASIC auth in .htaccess and remove/relax the API key check below.
+ *
+ * Endpoints (all return JSON; content-type: application/json):
+ *   GET  /api.php?res=staff                  -> staff roster (nurses/techs)
+ *   POST /api.php?res=staff                  -> replace staff (JSON body)
+ *
+ *   GET  /api.php?res=active&date=YYYY-MM-DD&shift=day|night
+ *   POST /api.php?res=active                 -> upsert current board state (expects {dateISO, shift, ...})
+ *
+ *   GET  /api.php?res=config                 -> board/site settings
+ *   POST /api.php?res=config                 -> replace config
+ *
+ *   GET  /api.php?res=history&date=YYYY-MM-DD -> shift snapshot for a date (combined day+night if stored)
+ *   POST /api.php?res=history                -> append/replace daily snapshot (expects {dateISO, shift, ...})
+ *
+ *   GET  /api.php?res=huddles&date=YYYY-MM-DD -> list/record of huddle notes for a date
+ *   POST /api.php?res=huddles                -> append or replace record
+ *
+ *   POST /api.php?res=reset&what=all|active|history|huddles|config|staff -> admin reset
+ *
+ * Notes:
+ * - Uses flock() for safe writes. Returns {ok:true, data:{...}} or {ok:false, error:"..."}
+ */
+
+header('Content-Type: application/json; charset=utf-8');
+
+// ----------- Config ----------- //
+$DATA_DIR = getenv('HEYBRE_DATA_DIR') ?: __DIR__ . '/data';
+$API_KEY  = getenv('HEYBRE_API_KEY') ?: ''; // define in hosting control panel or .htaccess
+$ALLOWED_ORIGINS = [
+  'https://board.heybre.com',
+  'http://board.heybre.com',
+  'https://www.board.heybre.com',
+  'http://www.board.heybre.com',
+  'https://heybre.com',
+  'http://heybre.com',
+  'http://localhost:5173',
+  'http://localhost'
+];
+
+// CORS (simple)
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+if ($origin && in_array($origin, $ALLOWED_ORIGINS, true)) {
+  header("Access-Control-Allow-Origin: $origin");
+  header("Vary: Origin");
+  header("Access-Control-Allow-Headers: Content-Type, X-API-Key");
+  header("Access-Control-Allow-Methods: GET, POST, OPTIONS");
+}
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+  http_response_code(204);
+  exit;
+}
+
+// ----------- Auth (simple API key) ----------- //
+function require_api_key(string $provided, string $configured) : void {
+  if ($configured === '') { return; } // disabled if not set
+  if (!hash_equals($configured, $provided ?: '')) {
+    http_response_code(401);
+    echo json_encode(['ok'=>false, 'error'=>'Unauthorized']);
+    exit;
+  }
+}
+
+// ----------- Helpers ----------- //
+function ensure_dir(string $dir) : void {
+  if (!is_dir($dir)) {
+    if (!mkdir($dir, 0775, true) && !is_dir($dir)) {
+      throw new RuntimeException("Cannot create data dir: $dir");
+    }
+  }
+}
+
+function p(string $name, $default = null) {
+  return $_GET[$name] ?? $_POST[$name] ?? $default;
+}
+
+function read_json(string $path) {
+  if (!file_exists($path)) return null;
+  $raw = file_get_contents($path);
+  if ($raw === false) throw new RuntimeException("Failed to read $path");
+  $decoded = json_decode($raw, true);
+  if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+    throw new RuntimeException("Invalid JSON in $path");
+  }
+  return $decoded;
+}
+
+function write_json_atomic(string $path, $data) : void {
+  $tmp = $path . '.tmp';
+  $fp = fopen($tmp, 'c+');
+  if (!$fp) throw new RuntimeException("Cannot open temp file for $path");
+  try {
+    if (!flock($fp, LOCK_EX)) throw new RuntimeException("Cannot lock temp file for $path");
+    ftruncate($fp, 0);
+    $bytes = fwrite($fp, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+    if ($bytes === false) throw new RuntimeException("Cannot write temp file for $path");
+    fflush($fp);
+    if (!rename($tmp, $path)) throw new RuntimeException("Cannot move temp file to $path");
+  } finally {
+    flock($fp, LOCK_UN);
+    fclose($fp);
+    if (file_exists($tmp)) @unlink($tmp);
+  }
+}
+
+function ok($data) {
+  echo json_encode(['ok'=>true, 'data'=>$data]);
+  exit;
+}
+function fail(string $msg, int $code=400) {
+  http_response_code($code);
+  echo json_encode(['ok'=>false, 'error'=>$msg]);
+  exit;
+}
+
+// ----------- Main ----------- //
+try {
+  ensure_dir($DATA_DIR);
+  $res = strtolower((string)p('res', ''));
+  $method = $_SERVER['REQUEST_METHOD'];
+  $provided_key = $_SERVER['HTTP_X_API_KEY'] ?? '';
+
+  $body = file_get_contents('php://input');
+  $jsonBody = null;
+  if ($body && strlen($body) > 0) {
+    $jsonBody = json_decode($body, true);
+    if ($jsonBody === null && json_last_error() !== JSON_ERROR_NONE) {
+      fail('Invalid JSON body', 400);
+    }
+  }
+
+  $paths = [
+    'staff'   => $DATA_DIR . '/staff.json',
+    'config'  => $DATA_DIR . '/config.json',
+  ];
+
+  if ($res === 'staff') {
+    if ($method === 'GET') {
+      $data = read_json($paths['staff']) ?? ['nurses'=>[], 'techs'=>[]];
+      ok($data);
+    } else if ($method === 'POST') {
+      require_api_key($provided_key, $API_KEY);
+      if (!is_array($jsonBody)) fail('Expected JSON object for staff');
+      write_json_atomic($paths['staff'], $jsonBody);
+      ok(['saved'=>true]);
+    } else {
+      fail('Method not allowed', 405);
+    }
+  }
+
+  if ($res === 'config') {
+    if ($method === 'GET') {
+      $data = read_json($paths['config']) ?? new stdClass();
+      ok($data);
+    } else if ($method === 'POST') {
+      require_api_key($provided_key, $API_KEY);
+      if (!is_array($jsonBody)) fail('Expected JSON object for config');
+      write_json_atomic($paths['config'], $jsonBody);
+      ok(['saved'=>true]);
+    } else {
+      fail('Method not allowed', 405);
+    }
+  }
+
+  if ($res === 'active') {
+    $dateISO = (string) p('date', $jsonBody['dateISO'] ?? '');
+    $shift   = (string) p('shift', $jsonBody['shift'] ?? '');
+    if (!$dateISO || !$shift) fail('Missing date or shift');
+
+    $file = $DATA_DIR . "/active-{$dateISO}-{$shift}.json";
+    if ($method === 'GET') {
+      $data = read_json($file) ?? new stdClass();
+      ok($data);
+    } else if ($method === 'POST') {
+      require_api_key($provided_key, $API_KEY);
+      if (!is_array($jsonBody)) fail('Expected JSON object for active');
+      write_json_atomic($file, $jsonBody);
+      ok(['saved'=>true]);
+    } else {
+      fail('Method not allowed', 405);
+    }
+  }
+
+  if ($res === 'history') {
+    $dateISO = (string) p('date', $jsonBody['dateISO'] ?? '');
+    if (!$dateISO) fail('Missing date');
+
+    $file = $DATA_DIR . "/history-{$dateISO}.json";
+    if ($method === 'GET') {
+      $data = read_json($file) ?? ['entries'=>[]];
+      ok($data);
+    } else if ($method === 'POST') {
+      require_api_key($provided_key, $API_KEY);
+      if (!is_array($jsonBody)) fail('Expected JSON object for history');
+      $existing = read_json($file) ?? ['entries'=>[]];
+      write_json_atomic($file, $jsonBody);
+      ok(['saved'=>true]);
+    } else {
+      fail('Method not allowed', 405);
+    }
+  }
+
+  if ($res === 'huddles') {
+    $dateISO = (string) p('date', $jsonBody['dateISO'] ?? p('date', ''));
+    if (!$dateISO) fail('Missing date');
+    $file = $DATA_DIR . "/huddles-{$dateISO}.json";
+    if ($method === 'GET') {
+      $data = read_json($file) ?? ['checks'=>[], 'notes'=>''];
+      ok($data);
+    } else if ($method === 'POST') {
+      require_api_key($provided_key, $API_KEY);
+      if (!is_array($jsonBody)) fail('Expected JSON object for huddles');
+      write_json_atomic($file, $jsonBody);
+      ok(['saved'=>true]);
+    } else {
+      fail('Method not allowed', 405);
+    }
+  }
+
+  if ($res === 'reset') {
+    require_api_key($provided_key, $API_KEY);
+    $what = (string) p('what', 'all');
+    $glob = [];
+    switch ($what) {
+      case 'all':
+        $glob = [
+          $DATA_DIR . '/active-*.json',
+          $DATA_DIR . '/history-*.json',
+          $DATA_DIR . '/huddles-*.json',
+          $DATA_DIR . '/config.json',
+        ];
+        break;
+      case 'active':  $glob = [ $DATA_DIR . '/active-*.json' ]; break;
+      case 'history': $glob = [ $DATA_DIR . '/history-*.json' ]; break;
+      case 'huddles': $glob = [ $DATA_DIR . '/huddles-*.json' ]; break;
+      case 'config':  $glob = [ $DATA_DIR . '/config.json' ]; break;
+      case 'staff':   $glob = [ $DATA_DIR . '/staff.json' ]; break;
+      default:        fail('Unknown reset target');
+    }
+    $deleted = [];
+    foreach ($glob as $g) foreach (glob($g) as $f) if (@unlink($f)) $deleted[] = basename($f);
+    ok(['deleted'=>$deleted]);
+  }
+
+  if ($res === '') ok(['hello'=>'heybre api']);
+  fail('Unknown resource', 404);
+
+} catch (Throwable $e) {
+  http_response_code(500);
+  echo json_encode(['ok'=>false, 'error'=>'Server error', 'detail'=>$e->getMessage()]);
+  exit;
+}
+

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
         if (el) el.textContent = 'App failed to load: ' + (e.message || 'Unknown error');
       });
     </script>
+    <script src="server-adapter.js"></script>
     <script type="module" src="/src/main.ts" defer></script>
   </body>
 </html>

--- a/reset.php
+++ b/reset.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+$API_KEY = getenv('HEYBRE_API_KEY') ?: '';
+$what = $_GET['what'] ?? 'all';
+$ch = curl_init((isset($_SERVER['HTTPS']) ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . '/api.php?res=reset&what=' . urlencode($what));
+curl_setopt_array($ch, [
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_POST => true,
+  CURLOPT_HTTPHEADER => $API_KEY ? ['X-API-Key: ' . $API_KEY] : [],
+]);
+$out = curl_exec($ch);
+$err = curl_error($ch);
+$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+header('Content-Type: application/json');
+if ($err) {
+  http_response_code(500);
+  echo json_encode(['ok'=>false, 'error'=>$err]);
+} else {
+  http_response_code($code);
+  echo $out;
+}
+

--- a/server-adapter.js
+++ b/server-adapter.js
@@ -1,0 +1,58 @@
+/* Minimal adapter to talk to the PHP API.
+   Include this BEFORE your app's main script:
+   <script src="server-adapter.js"></script>
+*/
+(function () {
+  const API_BASE = (window.location.origin + '/api.php');
+  const API_KEY = localStorage.getItem('HEYBRE_API_KEY') || ''; // set via DevTools once if you need writes
+
+  async function api(res, params = {}, method = 'GET', bodyObj = null) {
+    const qs = new URLSearchParams(params).toString();
+    const url = API_BASE + '?res=' + encodeURIComponent(res) + (qs ? '&' + qs : '');
+    const init = { method, headers: {} };
+    if (bodyObj) {
+      init.headers['Content-Type'] = 'application/json';
+      if (API_KEY) init.headers['X-API-Key'] = API_KEY;
+      init.body = JSON.stringify(bodyObj);
+    }
+    const r = await fetch(url, init);
+    const j = await r.json();
+    if (!j.ok) throw new Error(j.error || 'API error');
+    return j.data;
+  }
+
+  const STAFF_API = {
+    getStaff: () => api('staff'),
+    saveStaff: (staffObj) => api('staff', {}, 'POST', staffObj),
+
+    getActive: (dateISO, shift) => api('active', { date: dateISO, shift }),
+    saveActive: (stateObj) => api('active', {}, 'POST', stateObj),
+
+    getConfig: () => api('config'),
+    saveConfig: (cfg) => api('config', {}, 'POST', cfg),
+
+    getHistory: (dateISO) => api('history', { date: dateISO }),
+    saveHistory: (snapshot) => api('history', {}, 'POST', snapshot),
+
+    getHuddles: (dateISO) => api('huddles', { date: dateISO }),
+    saveHuddles: (h) => api('huddles', {}, 'POST', h),
+  };
+
+  window.STAFF_API = STAFF_API;
+
+  // Optional: override existing globals if present
+  if (typeof window.loadStaff === 'function') {
+    window.loadStaff = async () => STAFF_API.getStaff();
+  }
+  if (typeof window.saveStaff === 'function') {
+    window.saveStaff = async (s) => STAFF_API.saveStaff(s);
+  }
+  if (typeof window.getConfig === 'function') {
+    window.getConfig = async () => STAFF_API.getConfig();
+  }
+  if (typeof window.saveConfig === 'function') {
+    window.saveConfig = async (c) => STAFF_API.saveConfig(c);
+  }
+
+  console.log('[heybre] server adapter ready');
+})();


### PR DESCRIPTION
## Summary
- add minimal PHP API (`api.php`) and reset helper to persist staff board state
- expose JS adapter (`server-adapter.js`) and wire it into `index.html`
- document PHP deployment steps in README and add server-oriented `.htaccess`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0f8d76bb08327aa09c852a0375e54