### PR TITLE
fix: define global Server variable

### DIFF
--- a/public/server-adapter.js
+++ b/public/server-adapter.js
@@ -56,6 +56,7 @@
     document.body.removeChild(a);
   }
 
-  window.Server = { load, save, softDeleteStaff, exportHistoryCSV };
+  var Server = { load, save, softDeleteStaff, exportHistoryCSV };
+  window.Server = Server;
 })();
 


### PR DESCRIPTION
## Summary
- define global `Server` object and assign to window to prevent ReferenceError during app startup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b118a992b0832795c9c2a224ffd5e8