### PR TITLE
feat: poll active assignments

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -98,10 +98,23 @@ initState();
     }
   }, 10 * 60 * 1000);
 
+  const activeTimer = setInterval(async () => {
+    const { dateISO, shift } = STATE;
+    try {
+      const remote = await Server.load('active', { date: dateISO, shift });
+      const local = await DB.get(KS.ACTIVE(dateISO, shift));
+      if (remote && JSON.stringify(remote) !== JSON.stringify(local)) {
+        await DB.set(KS.ACTIVE(dateISO, shift), remote);
+        renderAll();
+      }
+    } catch {}
+  }, 60 * 1000);
+
     if (import.meta.hot) {
       import.meta.hot.dispose(() => {
         clearInterval(clockTimer);
         clearInterval(weatherTimer);
+        clearInterval(activeTimer);
       });
     }
   });


### PR DESCRIPTION
## Summary
- periodically fetch active board assignments from the server
- re-render board if assignments change for a 'live' experience

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b11e9185988327b015b22cf8dc07f0