### PR TITLE
fix: ensure builder zone drop works

### DIFF
--- a/src/ui/builder.ts
+++ b/src/ui/builder.ts
@@ -236,7 +236,10 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
         const ev = e as DragEvent;
         ev.dataTransfer?.setData('zone-index', String(i));
       });
-      section.addEventListener('dragover', (e) => e.preventDefault());
+      section.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      });
 
       const title = document.createElement('h2');
       title.className = 'zone-card__title';


### PR DESCRIPTION
## Summary
- stop zone section dragover from bubbling to container so drop events fire

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b11df5e2f883279d893fc2dc2a43b7