### PR TITLE
Fix drag selection in builder

### DIFF
--- a/src/ui/builder.ts
+++ b/src/ui/builder.ts
@@ -233,6 +233,7 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
       section.draggable = true;
       section.dataset.index = String(i);
       section.addEventListener('dragstart', (e) => {
+        if ((e.target as HTMLElement).closest('.nurse-row')) return;
         const ev = e as DragEvent;
         ev.dataTransfer?.setData('zone-index', String(i));
       });


### PR DESCRIPTION
## Summary
- prevent zone drag events when moving nurse rows in builder

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b12011bbf88327a7e6d6d02e4b7cdf