### PR TITLE
Ensure anchors default to day/night when missing

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -217,6 +217,11 @@ export function mergeConfigDefaults(): Config {
     };
   }
 
+  cfg.anchors = {
+    day: cfg.anchors?.day || '07:00',
+    night: cfg.anchors?.night || '19:00',
+  };
+
   cfg.zoneColors = cfg.zoneColors || {};
   ZONES_INVALID = false;
   const normalized = normalizeZones(cfg.zones as any);

--- a/tests/configAnchors.spec.ts
+++ b/tests/configAnchors.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/db', () => {
+  const store: Record<string, any> = {};
+  return {
+    get: async (k: string) => store[k],
+    set: async (k: string, v: any) => {
+      store[k] = v;
+    },
+    del: async (k: string) => {
+      delete store[k];
+    },
+    keys: async () => Object.keys(store),
+  };
+});
+
+vi.mock('@/server', () => ({
+  load: vi.fn().mockResolvedValue({
+    dateISO: '2024-01-01',
+    zones: [],
+    pin: '4911',
+    relockMin: 0,
+    widgets: {},
+    // anchors intentionally omitted to simulate older configs
+  }),
+  save: vi.fn(),
+  softDeleteStaff: vi.fn(),
+  exportHistoryCSV: vi.fn(),
+}));
+
+import { loadConfig } from '@/state';
+
+describe('config anchors defaults', () => {
+  it('adds day/night defaults when anchors missing', async () => {
+    const cfg = await loadConfig();
+    expect(cfg.anchors.day).toBe('07:00');
+    expect(cfg.anchors.night).toBe('19:00');
+  });
+});
+


### PR DESCRIPTION
## Summary
- Default `mergeConfigDefaults` to populate missing day/night anchors
- Add regression test verifying anchors defaulting

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b12040b03083278d7f14000babc652