### PR TITLE
Ensure config anchors default to day/night times

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -217,6 +217,17 @@ export function mergeConfigDefaults(): Config {
     };
   }
 
+  cfg.anchors = {
+    day:
+      typeof cfg.anchors?.day === 'string' && cfg.anchors.day
+        ? cfg.anchors.day
+        : '07:00',
+    night:
+      typeof cfg.anchors?.night === 'string' && cfg.anchors.night
+        ? cfg.anchors.night
+        : '19:00',
+  };
+
   cfg.zoneColors = cfg.zoneColors || {};
   ZONES_INVALID = false;
   const normalized = normalizeZones(cfg.zones as any);

--- a/tests/time.spec.ts
+++ b/tests/time.spec.ts
@@ -1,5 +1,20 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+vi.mock('@/db', () => {
+  const store: Record<string, any> = {};
+  return {
+    get: async (k: string) => store[k],
+    set: async (k: string, v: any) => {
+      store[k] = v;
+    },
+    del: async (k: string) => {
+      delete store[k];
+    },
+    keys: async () => Object.keys(store),
+  };
+});
 import { deriveShift, nextShiftTuple } from '@/utils/time';
+import { loadConfig } from '@/state';
+import { set } from '@/db';
 
 describe("deriveShift", () => {
   it("handles edges around anchors", () => {
@@ -20,5 +35,14 @@ describe("nextShiftTuple", () => {
       dateISO: "2024-01-02",
       shift: "day",
     });
+  });
+});
+
+describe("loadConfig anchors", () => {
+  it("fills default day/night anchors", async () => {
+    await set("CONFIG", { zones: [], anchors: { day: "08:00" } });
+    const cfg = await loadConfig();
+    expect(cfg.anchors.day).toBe("08:00");
+    expect(cfg.anchors.night).toBe("19:00");
   });
 });


### PR DESCRIPTION
## Summary
- populate missing config anchors with default day and night times
- add test confirming loadConfig supplies default anchors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b12089ee008327a461453f8582e501