### PR TITLE
Add refresh button to header

### DIFF
--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -1,7 +1,7 @@
 import { STATE, getConfig, DB, KS } from '@/state';
 import { getThemeConfig, saveThemeConfig, applyTheme } from '@/state/theme';
 import { deriveShift, fmtLong } from '@/utils/time';
-import { manualHandoff } from '@/main';
+import { manualHandoff, renderAll } from '@/main';
 import { openHuddle } from '@/ui/huddle';
 import { showBanner } from '@/ui/banner';
 
@@ -35,6 +35,7 @@ export function renderHeader() {
       <button id="theme-toggle" class="btn">🌓</button>
       ${actionBtn}
       <button id="publish-btn" class="btn">Sync</button>
+      <button id="refresh-btn" class="btn">Refresh</button>
       <button id="reset-cache" class="btn">Reset</button>
     </div>
   `;
@@ -66,6 +67,17 @@ export function renderHeader() {
       showBanner('Published');
     } catch {
       showBanner('Publish failed');
+    }
+  });
+  document.getElementById('refresh-btn')?.addEventListener('click', async () => {
+    try {
+      const { dateISO, shift } = STATE;
+      const board = await Server.load('active', { date: dateISO, shift });
+      if (board) await DB.set(KS.ACTIVE(dateISO, shift), board);
+      await renderAll();
+      showBanner('Refreshed');
+    } catch {
+      showBanner('Refresh failed');
     }
   });
   document.getElementById('reset-cache')?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add refresh button alongside Sync and Reset
- load latest active board data and update cache
- rerender board after refresh with user feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b12271513c8327a59d7e15a98ed474