### PR TITLE
refactor: update shift huddle checklist

### DIFF
--- a/src/config/huddle.ts
+++ b/src/config/huddle.ts
@@ -7,18 +7,12 @@ export interface HuddleItem {
 
 export const DEFAULT_HUDDLE_ITEMS: HuddleItem[] = [
   { id: 'staffing_ok', label: 'Staffing adequate', section: 'Staffing & Assignments', required: true },
-  { id: 'relief_plan', label: 'Relief/break coverage set', section: 'Staffing & Assignments' },
-  { id: 'bed_flow', label: 'Admit bed flow aligned', section: 'Throughput & Beds' },
-  { id: 'ems_status', label: 'EMS/diversion status reviewed', section: 'Throughput & Beds' },
   { id: 'ops_status', label: 'Imaging/Lab/IT status good', section: 'Operational Status' },
   { id: 'psych_sitter', label: 'Psych/sitter coverage', section: 'Operational Status' },
-  { id: 'code_ready', label: 'Code/airway/blood ready', section: 'Safety & Equipment', required: true },
-  { id: 'isolation_ok', label: 'Isolation/neg pressure OK', section: 'Safety & Equipment' },
   { id: 'stroke_ready', label: 'Stroke/TNK pathway ready', section: 'Time-Critical Protocols' },
   { id: 'stemi_ready', label: 'STEMI/PCI pathway ready', section: 'Time-Critical Protocols' },
-  { id: 'sepsis_watch', label: 'Sepsis bundle watchouts', section: 'Time-Critical Protocols' },
-  { id: 'trauma_plan', label: 'Trauma activation plan', section: 'Time-Critical Protocols' },
-  { id: 'roles_named', label: 'Roles named (Charge/Triage/Code)', section: 'Comms & Escalation', required: true },
+  { id: 'sepsis_watch', label: 'Open sepsis orders', section: 'Time-Critical Protocols' },
+  // An escalation path outlines who to contact when an issue needs additional assistance.
   { id: 'escalation_ok', label: 'Escalation path confirmed', section: 'Comms & Escalation' },
   { id: 'announcements', label: 'Announcements covered', section: 'Comms & Escalation' },
 ];


### PR DESCRIPTION
## Summary
- remove throughput, safety, relief and other unneeded shift huddle items
- rename sepsis bundle item to "Open sepsis orders"
- clarify escalation path purpose in checklist

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1293473cc832793da15a576863892