### PR TITLE
fix: unlock board by default

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -114,14 +114,14 @@ export interface AppState {
 const _clock = hhmmNowLocal();
 export const STATE: AppState = {
   dateISO: toDateISO(new Date()),
-  locked: true,
+  locked: false,
   clockHHMM: _clock,
   shift: deriveShift(_clock),
 };
 
 export function initState() {
   STATE.dateISO = toDateISO(new Date());
-  STATE.locked = true;
+  STATE.locked = false;
   STATE.clockHHMM = hhmmNowLocal();
   STATE.shift = deriveShift(STATE.clockHHMM);
 }

--- a/tests/lockState.spec.ts
+++ b/tests/lockState.spec.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { STATE, initState } from '@/state';
+
+describe('initState lock', () => {
+  it('unlocks board by default', () => {
+    STATE.locked = true;
+    initState();
+    expect(STATE.locked).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- default board state is unlocked
- add test confirming board initializes unlocked

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b12ee1f2948327b5b632f73ec21d84