### PR TITLE
feat: ensure board fits TV viewport

### DIFF
--- a/src/history/CalendarView.ts
+++ b/src/history/CalendarView.ts
@@ -1,7 +1,25 @@
-import { listShiftDates, getShiftByDate, savePublishedShift, indexStaffAssignments } from '@/state/history';
+import {
+  listShiftDates,
+  getShiftByDate,
+  savePublishedShift,
+  indexStaffAssignments,
+  PublishedShiftSnapshot,
+} from '@/state/history';
 import { exportShiftCSV } from '@/history';
 import { DB, KS } from '@/state';
 import './history.css';
+
+function isPublishedShiftSnapshot(obj: any): obj is PublishedShiftSnapshot {
+  return (
+    obj &&
+    typeof obj === 'object' &&
+    'version' in obj &&
+    'dateISO' in obj &&
+    'shift' in obj &&
+    'publishedAtISO' in obj &&
+    'publishedBy' in obj
+  );
+}
 
 /** Render the calendar-based history view with listing, saving, and export. */
 export function renderCalendarView(root: HTMLElement): void {
@@ -62,11 +80,11 @@ export function renderCalendarView(root: HTMLElement): void {
     if (!d) return;
     const day = await DB.get(KS.ACTIVE(d, 'day')).catch(() => null);
     const night = await DB.get(KS.ACTIVE(d, 'night')).catch(() => null);
-    if (day && typeof day === 'object' && 'version' in day) {
+    if (isPublishedShiftSnapshot(day)) {
       await savePublishedShift(day);
       await indexStaffAssignments(day);
     }
-    if (night && typeof night === 'object' && 'version' in night) {
+    if (isPublishedShiftSnapshot(night)) {
       await savePublishedShift(night);
       await indexStaffAssignments(night);
     }

--- a/src/history/CalendarView.ts
+++ b/src/history/CalendarView.ts
@@ -62,11 +62,11 @@ export function renderCalendarView(root: HTMLElement): void {
     if (!d) return;
     const day = await DB.get(KS.ACTIVE(d, 'day')).catch(() => null);
     const night = await DB.get(KS.ACTIVE(d, 'night')).catch(() => null);
-    if (day) {
+    if (day && typeof day === 'object' && 'version' in day) {
       await savePublishedShift(day);
       await indexStaffAssignments(day);
     }
-    if (night) {
+    if (night && typeof night === 'object' && 'version' in night) {
       await savePublishedShift(night);
       await indexStaffAssignments(night);
     }

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,7 +4,7 @@
   --control:#1a2030; --tab:#1a2435;
   --gap:18px; --radius:14px; --cell:clamp(54px,4.8vh,70px);
   --scale:1;
-  --f-base:clamp(16px,1.05vw,19px); --f-lg-base:clamp(19px,1.5vw,24px); --f-xl-base:clamp(26px,2.4vw,34px);
+  --f-base:clamp(14px,1.2vw,20px); --f-lg-base:clamp(18px,1.8vw,28px); --f-xl-base:clamp(24px,2.4vw,36px);
   --f:calc(var(--f-base)*var(--scale)); --f-lg:calc(var(--f-lg-base)*var(--scale)); --f-xl:calc(var(--f-xl-base)*var(--scale));
 
   --elev-1: 0 2px 8px rgba(0,0,0,.25);
@@ -79,7 +79,7 @@
 }
 
 *{box-sizing:border-box}
-html,body{height:100%}
+html,body{height:100%;overflow:hidden}
 body{margin:0;background:var(--bg);color:var(--text-high);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
 .wrap{max-width:1920px;margin:0 auto;padding:var(--gap)}
 header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-items:center;margin-bottom:var(--gap);position:sticky;top:0;z-index:var(--z-sticky)}
@@ -92,12 +92,15 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 
 /* choose the variable-based sidebar width */
 .layout{display:grid;grid-template-columns:1fr var(--right-sidebar-w);gap:var(--gap)}
+.layout[data-testid="main-board"]{height:100vh;overflow:hidden}
 .builder-layout{grid-template-columns:minmax(200px,25%) 1fr}
 
-.panel{background:var(--panel);color:var(--text-high);border:1px solid var(--line);border-radius:var(--radius);padding:12px 14px;box-shadow:var(--elev-1)}
+.panel{background:var(--panel);color:var(--text-high);border:1px solid var(--line);border-radius:var(--radius);padding:12px 14px;box-shadow:var(--elev-1);display:flex;flex-direction:column;min-height:0}
 .panel h3{color:var(--text-high);font-size:clamp(14px,.95vw,16px)}
 .panel .muted{color:var(--text-muted)}
-.zones-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:clamp(8px,1.5vw,12px);max-width:1520px;margin:0 auto}
+.col{display:flex;flex-direction:column;gap:var(--gap);height:100%;min-height:0;overflow:hidden}
+.col>.panel{flex:1}
+.zones-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:clamp(8px,1.5vw,12px);max-width:1520px;margin:0 auto;flex:1;grid-auto-rows:1fr}
 
 @media (max-width:900px){
   .layout{grid-template-columns:1fr}
@@ -121,6 +124,7 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .form-grid{display:grid;grid-template-columns:repeat(3,minmax(200px,1fr));gap:10px}
 .btn-row{display:flex;gap:8px;margin-top:8px}
 .input,input,select,textarea{background:var(--control);color:var(--text-high);border:1px solid var(--line);border-radius:8px;padding:6px 8px}
+.panel textarea{flex:1}
 .btn{background:var(--tab);border:1px solid var(--line);border-radius:8px;padding:6px 10px;cursor:pointer}
 .muted{color:var(--text-muted)}
 .single-line{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -139,6 +139,9 @@ export async function renderBoard(
     renderOffgoing(active, queueSave);
     await renderWeather(document.getElementById('weather-body')!);
 
+    testBoardFit();
+    window.addEventListener('resize', testBoardFit);
+
     // Re-render on config changes (e.g., zone list or colors)
     document.addEventListener('config-changed', () => {
       const c = getConfig();
@@ -158,6 +161,26 @@ export async function renderBoard(
       renderBoard(root, ctx);
     });
   }
+}
+
+/** Log and ensure the board fits within the viewport. */
+export function testBoardFit(): boolean {
+  const board = document.querySelector('[data-testid="main-board"]') as HTMLElement | null;
+  if (!board) return true;
+  const viewport = window.innerHeight;
+  const boardHeight = board.getBoundingClientRect().height;
+  const fits = boardHeight <= viewport;
+  console.log(`board height ${boardHeight}, viewport ${viewport}, fits: ${fits}`);
+  if (!fits) {
+    const scale = viewport / boardHeight;
+    board.style.transformOrigin = 'top left';
+    board.style.transform = `scale(${scale})`;
+    document.documentElement.style.setProperty('--scale', String(scale));
+  } else {
+    board.style.transform = '';
+    document.documentElement.style.setProperty('--scale', '1');
+  }
+  return fits;
 }
 
 // --- leadership ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- scale fonts and layout with `clamp()` variables and full screen grid
- disable scroll and flex panels so board content fills the TV viewport
- add `testBoardFit` utility that auto-scales the board when taller than the screen

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b132e8d3288327806eea21a18876c9