### PR TITLE
Auto-hide sync banners and display physician roster

### DIFF
--- a/src/ui/banner.ts
+++ b/src/ui/banner.ts
@@ -1,4 +1,6 @@
 /** Display a non-blocking banner message at top of the page. */
+let bannerTimer: number | undefined;
+
 export function showBanner(msg: string): void {
   let el = document.getElementById('app-banner');
   if (!el) {
@@ -8,4 +10,8 @@ export function showBanner(msg: string): void {
     document.body.prepend(el);
   }
   el.textContent = msg;
+  if (bannerTimer) clearTimeout(bannerTimer);
+  bannerTimer = window.setTimeout(() => {
+    el?.remove();
+  }, 10_000);
 }

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -16,6 +16,7 @@ import {
 } from '@/state';
 import { setNurseCache, labelFromId } from '@/utils/names';
 import { renderWeather } from './widgets';
+import { renderPhysicians } from './physicians';
 import { nurseTile } from './nurseTile';
 import { debouncedSave } from '@/utils/debouncedSave';
 import './mainBoard/boardLayout.css';
@@ -138,6 +139,10 @@ export async function renderBoard(
     await renderIncoming(active, queueSave);
     renderOffgoing(active, queueSave);
     await renderWeather(document.getElementById('weather-body')!);
+    await renderPhysicians(
+      document.getElementById('phys') as HTMLElement,
+      ctx.dateISO
+    );
 
     // Re-render on config changes (e.g., zone list or colors)
     document.addEventListener('config-changed', () => {

--- a/src/ui/physicians.ts
+++ b/src/ui/physicians.ts
@@ -1,0 +1,68 @@
+const CAL_URL = 'https://www.bytebloc.com/sk/?76b6a156';
+
+type Event = {
+  date: string;
+  summary: string;
+  location: string;
+};
+
+function parseICS(text: string): Event[] {
+  const rawLines = text.split(/\r?\n/);
+  const lines: string[] = [];
+  for (const line of rawLines) {
+    if (line.startsWith(' ') || line.startsWith('\t')) {
+      lines[lines.length - 1] += line.slice(1);
+    } else {
+      lines.push(line);
+    }
+  }
+  const events: Event[] = [];
+  let current: Record<string, string> | null = null;
+  for (const line of lines) {
+    if (line === 'BEGIN:VEVENT') {
+      current = {};
+    } else if (line === 'END:VEVENT') {
+      if (current?.DTSTART && current.SUMMARY) {
+        const d = current.DTSTART.replace(/[^0-9]/g, '').slice(0, 8);
+        const dateISO = `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`;
+        events.push({
+          date: dateISO,
+          summary: current.SUMMARY,
+          location: current.LOCATION || '',
+        });
+      }
+      current = null;
+    } else if (current) {
+      const idx = line.indexOf(':');
+      if (idx > -1) {
+        const key = line.slice(0, idx);
+        const value = line.slice(idx + 1);
+        current[key] = value;
+      }
+    }
+  }
+  return events;
+}
+
+/** Fetch and render physicians for the given day. */
+export async function renderPhysicians(el: HTMLElement, dateISO: string): Promise<void> {
+  try {
+    const res = await fetch(CAL_URL);
+    if (!res.ok) throw new Error('failed');
+    const ics = await res.text();
+    const events = parseICS(ics);
+    const docs = events
+      .filter((e) => e.date === dateISO && /jewish downtown/i.test(e.location))
+      .map((e) => e.summary.trim());
+    if (docs.length === 0) {
+      el.textContent = 'No physicians scheduled';
+      return;
+    }
+    el.innerHTML = `<ul>${docs.map((d) => `<li>${d}</li>`).join('')}</ul>`;
+  } catch {
+    el.textContent = 'Physician schedule unavailable';
+  }
+}
+
+// Exported for testing if needed
+export const __test = { parseICS };

--- a/tests/banner.spec.ts
+++ b/tests/banner.spec.ts
@@ -1,0 +1,15 @@
+/** @vitest-environment happy-dom */
+import { describe, it, expect, vi } from 'vitest';
+import { showBanner } from '@/ui/banner';
+
+describe('showBanner', () => {
+  it('removes banner after 10 seconds', () => {
+    vi.useFakeTimers();
+    showBanner('hello');
+    const el = document.getElementById('app-banner');
+    expect(el).toBeTruthy();
+    vi.advanceTimersByTime(10_000);
+    expect(document.getElementById('app-banner')).toBeNull();
+    vi.useRealTimers();
+  });
+});

--- a/tests/physicians.spec.ts
+++ b/tests/physicians.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { __test } from '@/ui/physicians';
+
+describe('physician schedule parsing', () => {
+  it('extracts events from ICS', () => {
+    const sample = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'DTSTART:20240101T070000',
+      'SUMMARY:Dr A',
+      'LOCATION:Jewish Downtown',
+      'END:VEVENT',
+      'BEGIN:VEVENT',
+      'DTSTART:20240101T070000',
+      'SUMMARY:Dr B',
+      'LOCATION:Other',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\n');
+    const events = __test.parseICS(sample);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({
+      date: '2024-01-01',
+      summary: 'Dr A',
+      location: 'Jewish Downtown',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Auto-hide sync/refresh banners after 10 seconds
- Fetch and display physician schedule from ByteBloc calendar
- Add unit tests for banner behavior and schedule parsing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b134bc239c83279a84213ebe0259d9