### PR TITLE
Guard roster resize against missing element

### DIFF
--- a/src/ui/builder.ts
+++ b/src/ui/builder.ts
@@ -82,8 +82,12 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
   renderZones();
   renderLeads();
 
-  function adjustRosterHeight() {
-    const cont = document.getElementById('builder-roster') as HTMLElement;
+  function adjustRosterHeight(): void {
+    const cont = document.getElementById('builder-roster');
+    if (!cont) {
+      window.removeEventListener('resize', adjustRosterHeight);
+      return;
+    }
     const top = cont.getBoundingClientRect().top;
     cont.style.maxHeight = `${window.innerHeight - top}px`;
     cont.style.overflow = 'hidden';


### PR DESCRIPTION
## Summary
- avoid calling `getBoundingClientRect` on a missing roster container and remove resize listener when absent

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b138f66c088327b91a1dbd94e2e671