### PR TITLE
fix: guard roster height calc

### DIFF
--- a/src/ui/builder.ts
+++ b/src/ui/builder.ts
@@ -83,7 +83,8 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
   renderLeads();
 
   function adjustRosterHeight() {
-    const cont = document.getElementById('builder-roster') as HTMLElement;
+    const cont = document.getElementById('builder-roster');
+    if (!cont) return;
     const top = cont.getBoundingClientRect().top;
     cont.style.maxHeight = `${window.innerHeight - top}px`;
     cont.style.overflow = 'hidden';


### PR DESCRIPTION
## Summary
- avoid getBoundingClientRect on missing builder roster element

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1394242dc8327ba76dae4ad2ac81b