### PR TITLE
Enable scrolling on main board

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -79,7 +79,7 @@
 }
 
 *{box-sizing:border-box}
-html,body{height:100%;overflow:hidden}
+html,body{height:100%;overflow:auto}
 body{margin:0;background:var(--bg);color:var(--text-high);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
 .wrap{max-width:1920px;margin:0 auto;padding:var(--gap)}
 header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-items:center;margin-bottom:var(--gap);position:sticky;top:0;z-index:var(--z-sticky)}
@@ -92,7 +92,7 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 
 /* choose the variable-based sidebar width */
 .layout{display:grid;grid-template-columns:1fr var(--right-sidebar-w);gap:var(--gap)}
-.layout[data-testid="main-board"]{height:100vh;overflow:hidden}
+.layout[data-testid="main-board"]{min-height:100vh}
 .builder-layout{grid-template-columns:minmax(200px,25%) 1fr}
 
 .panel{background:var(--panel);color:var(--text-high);border:1px solid var(--line);border-radius:var(--radius);padding:12px 14px;box-shadow:var(--elev-1);display:flex;flex-direction:column;min-height:0}


### PR DESCRIPTION
## Summary
- allow page scrolling by removing hidden overflow on `html` and `body`
- let main board layout grow with content using `min-height:100vh`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b13d2d45b88327b94d1036f7e2d55a