### PR TITLE
Limit panel flex to specific sections

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -99,7 +99,8 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .panel h3{color:var(--text-high);font-size:clamp(14px,.95vw,16px)}
 .panel .muted{color:var(--text-muted)}
 .col{display:flex;flex-direction:column;gap:var(--gap);height:100%;min-height:0;overflow:hidden}
-.col>.panel{flex:1}
+.col>.panel{flex:0 0 auto}
+#incoming,#offgoing{flex:1}
 .zones-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:clamp(8px,1.5vw,12px);max-width:1520px;margin:0 auto;flex:1;grid-auto-rows:1fr}
 
 @media (max-width:900px){


### PR DESCRIPTION
## Summary
- Default panels to `flex:0 0 auto` instead of flexing to fill columns
- Allow only incoming and offgoing sections to expand with `flex:1`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b13f52649c8327ae22f3d3c780c4d0