### PR TITLE
style: allow zone grid auto height

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -100,7 +100,7 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .panel .muted{color:var(--text-muted)}
 .col{display:flex;flex-direction:column;gap:var(--gap);height:100%;min-height:0;overflow:hidden}
 .col>.panel{flex:1}
-.zones-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:clamp(8px,1.5vw,12px);max-width:1520px;margin:0 auto;flex:1;grid-auto-rows:1fr}
+.zones-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:clamp(8px,1.5vw,12px);max-width:1520px;margin:0 auto;flex:1;grid-auto-rows:auto}
 
 @media (max-width:900px){
   .layout{grid-template-columns:1fr}


### PR DESCRIPTION
## Summary
- allow zone grid rows to auto size instead of filling equally

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b13f5400e883279a2cf5dbc078f6d4