### PR TITLE
Enable vertical scrolling on main board

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -93,6 +93,7 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 /* choose the variable-based sidebar width */
 .layout{display:grid;grid-template-columns:1fr var(--right-sidebar-w);gap:var(--gap)}
 .layout[data-testid="main-board"]{min-height:100vh}
+.layout[data-testid="main-board"] .col{height:auto;overflow:visible}
 .builder-layout{grid-template-columns:minmax(200px,25%) 1fr}
 
 .panel{background:var(--panel);color:var(--text-high);border:1px solid var(--line);border-radius:var(--radius);padding:12px 14px;box-shadow:var(--elev-1);display:flex;flex-direction:column;min-height:0}

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -144,8 +144,7 @@ export async function renderBoard(
       ctx.dateISO
     );
 
-    testBoardFit();
-    window.addEventListener('resize', testBoardFit);
+    // Removed testBoardFit call; allow natural scroll for overflow
 
     // Re-render on config changes (e.g., zone list or colors)
     document.addEventListener('config-changed', () => {
@@ -168,25 +167,7 @@ export async function renderBoard(
   }
 }
 
-/** Log and ensure the board fits within the viewport. */
-export function testBoardFit(): boolean {
-  const board = document.querySelector('[data-testid="main-board"]') as HTMLElement | null;
-  if (!board) return true;
-  const viewport = window.innerHeight;
-  const boardHeight = board.getBoundingClientRect().height;
-  const fits = boardHeight <= viewport;
-  console.log(`board height ${boardHeight}, viewport ${viewport}, fits: ${fits}`);
-  if (!fits) {
-    const scale = viewport / boardHeight;
-    board.style.transformOrigin = 'top left';
-    board.style.transform = `scale(${scale})`;
-    document.documentElement.style.setProperty('--scale', String(scale));
-  } else {
-    board.style.transform = '';
-    document.documentElement.style.setProperty('--scale', '1');
-  }
-  return fits;
-}
+
 
 // --- leadership ------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- remove `testBoardFit` scaling logic from board
- allow main board columns to overflow and scroll normally

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b13f557868832796360ab9f4e332c5