### PR TITLE
Expand wrap container to full width

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -81,7 +81,7 @@
 *{box-sizing:border-box}
 html,body{height:100%;overflow:auto}
 body{margin:0;background:var(--bg);color:var(--text-high);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
-.wrap{max-width:1920px;margin:0 auto;padding:var(--gap)}
+.wrap{width:100%;padding:var(--gap)}
 header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-items:center;margin-bottom:var(--gap);position:sticky;top:0;z-index:var(--z-sticky)}
 .title{font-size:var(--f-xl);font-weight:800;letter-spacing:.2px}
 .subtitle{color:var(--text-muted);font-size:var(--f)}


### PR DESCRIPTION
## Summary
- let `.wrap` span the full viewport width by replacing `max-width` with `width:100%` and removing centering margin

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b144faff508327a4cffd2ba97b384d