### PR TITLE
Fix flex behavior for incoming and offgoing panels

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -108,8 +108,8 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .panel .muted{color:var(--text-muted)}
 .col{display:flex;flex-direction:column;gap:var(--gap);height:100%;min-height:0;overflow:hidden}
 /* merged resolution */
-.col>.panel{flex:1}
-#incoming,#offgoing{flex:1}
+.col>.panel{flex:0 0 auto}
+#incoming-panel,#offgoing-panel{flex:1}
 .zones-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:clamp(8px,1.5vw,12px);max-width:1520px;margin:0 auto;flex:1;grid-auto-rows:auto}
 
 @media (max-width:900px){

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -104,13 +104,13 @@ export async function renderBoard(
             <div id="weather-body"></div>
           </section>
 
-          <section class="panel">
+          <section id="incoming-panel" class="panel">
             <h3>Incoming (click to toggle arrived)</h3>
             <button id="add-incoming" class="btn">+ Add</button>
             <div id="incoming" style="min-height:40px"></div>
           </section>
 
-          <section class="panel">
+          <section id="offgoing-panel" class="panel">
             <h3>Offgoing (kept 40 min)</h3>
             <div id="offgoing"></div>
           </section>


### PR DESCRIPTION
## Summary
- ensure only incoming and offgoing panels flex to occupy column height
- add identifiers to corresponding panel sections

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1aa2d6a7883279c77cd70a21c4060