### PR TITLE
feat: add theme presets with contrast-safe options

### DIFF
--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -1,26 +1,253 @@
 import { getConfig, saveConfig } from '@/state';
 
 export type UIMode = 'system' | 'light' | 'dark';
+
+/** Tokens used to populate CSS variables for theming. */
+export interface ThemeTokens {
+  bg: string;
+  panel: string;
+  text: string;
+  muted: string;
+  accent: string;
+  ok: string;
+  warn: string;
+  danger: string;
+  line: string;
+  slot: string;
+  control: string;
+  tab: string;
+}
+
+/** Preset definition including its color tokens. */
+export interface ThemePreset {
+  id: string;
+  label: string;
+  mode: 'light' | 'dark';
+  note?: string;
+  tokens: ThemeTokens;
+}
+
+/** Persisted theme configuration. */
 export interface UIThemeConfig {
   mode: UIMode;
   scale: number;
-  lightPreset: 'paper' | 'fog' | 'pearl';
-  darkPreset: 'ink' | 'midnight' | 'plum';
+  lightPreset: string;
+  darkPreset: string;
+  custom?: Partial<ThemeTokens>;
   highContrast?: boolean;
   compact?: boolean;
 }
 
+/** Available light and dark presets. */
+export const THEME_PRESETS: ThemePreset[] = [
+  {
+    id: 'light-soft-gray',
+    label: 'Soft Gray + Charcoal',
+    mode: 'light',
+    note: 'Fluorescent-friendly',
+    tokens: {
+      bg: '#F3F4F6',
+      panel: '#FFFFFF',
+      text: '#111827',
+      muted: '#6B7280',
+      accent: '#2563EB',
+      ok: '#16A34A',
+      warn: '#F59E0B',
+      danger: '#DC2626',
+      line: '#E5E7EB',
+      slot: '#F8FAFC',
+      control: '#E5E7EB',
+      tab: '#E5E7EB',
+    },
+  },
+  {
+    id: 'light-warm-beige',
+    label: 'Warm Beige + Charcoal',
+    mode: 'light',
+    note: 'Reduced glare',
+    tokens: {
+      bg: '#F7F3E8',
+      panel: '#FFFFFF',
+      text: '#2C2C2C',
+      muted: '#6B6B6B',
+      accent: '#8B5CF6',
+      ok: '#22C55E',
+      warn: '#D97706',
+      danger: '#B91C1C',
+      line: '#E9E5DA',
+      slot: '#FAF9F6',
+      control: '#E9E5DA',
+      tab: '#E9E5DA',
+    },
+  },
+  {
+    id: 'light-pale-blue',
+    label: 'Pale Blue + Navy',
+    mode: 'light',
+    note: 'My pick for TVs',
+    tokens: {
+      bg: '#EAF2FB',
+      panel: '#FFFFFF',
+      text: '#0B2545',
+      muted: '#4B5563',
+      accent: '#1D4ED8',
+      ok: '#16A34A',
+      warn: '#D97706',
+      danger: '#B91C1C',
+      line: '#D9E3F2',
+      slot: '#F7FAFE',
+      control: '#D9E3F2',
+      tab: '#D9E3F2',
+    },
+  },
+  {
+    id: 'light-soft-sage',
+    label: 'Soft Sage + Deep Green',
+    mode: 'light',
+    tokens: {
+      bg: '#EEF5EF',
+      panel: '#FFFFFF',
+      text: '#1B4332',
+      muted: '#4B6B61',
+      accent: '#2E7D32',
+      ok: '#22C55E',
+      warn: '#CA8A04',
+      danger: '#B91C1C',
+      line: '#DCE8DF',
+      slot: '#F6FAF7',
+      control: '#DCE8DF',
+      tab: '#DCE8DF',
+    },
+  },
+  {
+    id: 'light-muted-cream',
+    label: 'Muted Cream + Slate',
+    mode: 'light',
+    tokens: {
+      bg: '#FFF9E6',
+      panel: '#FFFFFF',
+      text: '#2F4F4F',
+      muted: '#667A7A',
+      accent: '#D97706',
+      ok: '#16A34A',
+      warn: '#D97706',
+      danger: '#B91C1C',
+      line: '#F2E8C8',
+      slot: '#FFFBEE',
+      control: '#F2E8C8',
+      tab: '#F2E8C8',
+    },
+  },
+  {
+    id: 'dark-charcoal-navy',
+    label: 'Charcoal + Navy',
+    mode: 'dark',
+    tokens: {
+      bg: '#0E1117',
+      panel: '#141925',
+      text: '#E6EDF3',
+      muted: '#AEB9CF',
+      accent: '#4AA3FF',
+      ok: '#28C990',
+      warn: '#F5A524',
+      danger: '#EF5B5B',
+      line: '#273044',
+      slot: '#111726',
+      control: '#1A2030',
+      tab: '#1A2435',
+    },
+  },
+  {
+    id: 'dark-ink-slate',
+    label: 'Ink + Slate',
+    mode: 'dark',
+    tokens: {
+      bg: '#111827',
+      panel: '#1F2937',
+      text: '#E5E7EB',
+      muted: '#9CA3AF',
+      accent: '#60A5FA',
+      ok: '#34D399',
+      warn: '#F59E0B',
+      danger: '#F87171',
+      line: '#374151',
+      slot: '#111827',
+      control: '#1F2937',
+      tab: '#1F2937',
+    },
+  },
+  {
+    id: 'dark-plum',
+    label: 'Deep Plum + Lavender',
+    mode: 'dark',
+    tokens: {
+      bg: '#1B0E1E',
+      panel: '#2A1530',
+      text: '#F3E8FF',
+      muted: '#C4B5FD',
+      accent: '#A78BFA',
+      ok: '#34D399',
+      warn: '#F59E0B',
+      danger: '#F87171',
+      line: '#3A2540',
+      slot: '#1B0E1E',
+      control: '#2A1530',
+      tab: '#2A1530',
+    },
+  },
+  {
+    id: 'dark-forest',
+    label: 'Forest Night + Mint',
+    mode: 'dark',
+    tokens: {
+      bg: '#0F1A14',
+      panel: '#142219',
+      text: '#E8F5E9',
+      muted: '#A7DCC3',
+      accent: '#34D399',
+      ok: '#34D399',
+      warn: '#F59E0B',
+      danger: '#F87171',
+      line: '#1E2C23',
+      slot: '#0F1A14',
+      control: '#142219',
+      tab: '#142219',
+    },
+  },
+  {
+    id: 'dark-graphite-amber',
+    label: 'Graphite + Amber',
+    mode: 'dark',
+    tokens: {
+      bg: '#121212',
+      panel: '#1E1E1E',
+      text: '#F5F5F5',
+      muted: '#CFCFCF',
+      accent: '#F5A524',
+      ok: '#34D399',
+      warn: '#F5A524',
+      danger: '#EF5B5B',
+      line: '#2A2A2A',
+      slot: '#131313',
+      control: '#1E1E1E',
+      tab: '#1E1E1E',
+    },
+  },
+];
+
 const DEFAULT_THEME: UIThemeConfig = {
   mode: 'system',
   scale: 1,
-  lightPreset: 'fog',
-  darkPreset: 'midnight',
+  lightPreset: 'light-soft-gray',
+  darkPreset: 'dark-charcoal-navy',
 };
 
+/** Get the current theme configuration merged with defaults. */
 export function getThemeConfig(): UIThemeConfig {
   return { ...DEFAULT_THEME, ...(getConfig().uiTheme || {}) };
 }
 
+/** Persist theme settings and apply them. */
 export async function saveThemeConfig(partial: Partial<UIThemeConfig>): Promise<UIThemeConfig> {
   const next = { ...getThemeConfig(), ...partial };
   await saveConfig({ uiTheme: next });
@@ -29,6 +256,7 @@ export async function saveThemeConfig(partial: Partial<UIThemeConfig>): Promise<
   return next;
 }
 
+/** Apply the theme configuration to the document root. */
 export function applyTheme(cfg: UIThemeConfig = getThemeConfig()): void {
   const r = document.documentElement;
   r.style.setProperty('--scale', String(cfg?.scale ?? 1));
@@ -37,22 +265,20 @@ export function applyTheme(cfg: UIThemeConfig = getThemeConfig()): void {
   const isDark = mode === 'dark' || (mode === 'system' && prefersDark);
   r.setAttribute('data-theme', isDark ? 'dark' : 'light');
 
-  const lightPresets = {
-    paper: { '--bg': '#fdfdfd', '--panel': '#ffffff' },
-    fog: { '--bg': '#f7f9fc', '--panel': '#ffffff' },
-    pearl: { '--bg': '#f6f7fb', '--panel': '#ffffff' },
-  } as Record<string, Record<string, string>>;
-  const darkPresets = {
-    ink: { '--bg': '#0b0e14', '--panel': '#121826' },
-    midnight: { '--bg': '#0e1117', '--panel': '#141925' },
-    plum: { '--bg': '#0e0b12', '--panel': '#171327' },
-  } as Record<string, Record<string, string>>;
-
-  const preset = isDark
-    ? darkPresets[cfg?.darkPreset || 'midnight']
-    : lightPresets[cfg?.lightPreset || 'fog'];
-  if (preset) {
-    for (const [k, v] of Object.entries(preset)) r.style.setProperty(k, v);
+  const presetId = isDark ? cfg.darkPreset : cfg.lightPreset;
+  const preset = THEME_PRESETS.find((p) => p.id === presetId);
+  const tokens = { ...(preset?.tokens || {}), ...(cfg.custom || {}) } as ThemeTokens;
+  for (const [k, v] of Object.entries(tokens)) {
+    r.style.setProperty(`--${k}`, v);
+    if (k === 'text') {
+      r.style.setProperty('--text-high', v);
+      r.style.setProperty('--text', v);
+    }
+    if (k === 'muted') {
+      r.style.setProperty('--text-muted', v);
+      r.style.setProperty('--muted', v);
+      r.style.setProperty('--text-med', v);
+    }
   }
 
   if (cfg?.highContrast) {
@@ -67,3 +293,4 @@ export function applyTheme(cfg: UIThemeConfig = getThemeConfig()): void {
     r.style.removeProperty('--gap');
   }
 }
+

--- a/src/styles.css
+++ b/src/styles.css
@@ -170,7 +170,7 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 
 @media print{
   #widgets,.widget{display:none!important}
-  .zone-card,.nurse-card{background:#fff!important;color:#000!important;box-shadow:none!important}
+.zone-card,.nurse-card{background:var(--panel)!important;color:var(--text-high)!important;box-shadow:none!important}
 }
 
 .overlay,.backdrop,.modal-backdrop{position:fixed;inset:0;z-index:var(--z-modal)}
@@ -214,3 +214,9 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .manage-dialog label{display:flex;flex-direction:column;gap:4px}
 .manage-dialog .dialog-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:8px}
 .banner{background:var(--danger);color:var(--text);padding:8px;text-align:center}
+
+.preset-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:8px;margin:8px 0}
+.preset-card{display:flex;flex-direction:column;gap:4px;border:1px solid var(--line);border-radius:8px;padding:6px;background:var(--control)}
+.swatches{display:flex;gap:4px}
+.swatch{flex:1;height:12px;border-radius:4px}
+.preset-meta{display:flex;flex-direction:column;font-size:.85em}

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -10,7 +10,14 @@ import { createStaffId, ensureStaffId } from '@/utils/id';
 import { fetchWeather, renderWeather } from './widgets';
 import { getUIConfig, saveUIConfig, applyUI } from '@/state/uiConfig';
 import { renderHeader } from '@/ui/header';
-import { getThemeConfig, saveThemeConfig, applyTheme } from '@/state/theme';
+import {
+  getThemeConfig,
+  saveThemeConfig,
+  applyTheme,
+  THEME_PRESETS,
+  type UIMode,
+  type ThemePreset,
+} from '@/state/theme';
 
 function mapIcon(cond: string) {
   const c = (cond || '').toLowerCase();
@@ -198,12 +205,13 @@ function renderGeneralSettings() {
   const cfg = getConfig();
   const ui = getUIConfig();
   const el = document.getElementById('general-settings')!;
-  const palette = [
-    '#3b82f6', '#2563eb', '#1d4ed8', // blues
-    '#ef4444', '#b91c1c',             // reds
-    '#10b981', '#047857',             // greens
-    '#8b5cf6',                        // purple
+  const paletteVars = [
+    '--zone-bg-1', '--zone-bg-2', '--zone-bg-3',
+    '--zone-bg-4', '--zone-bg-5',
+    '--zone-bg-6', '--zone-bg-7', '--zone-bg-8',
   ];
+  const style = getComputedStyle(document.documentElement);
+  const palette = paletteVars.map((v) => style.getPropertyValue(v).trim());
   const zoneOptions = (z: string, sel: string | undefined) =>
     `<select data-zone="${z}" class="zone-sel">` +
     '<option value="">Default</option>' +
@@ -290,7 +298,7 @@ function renderGeneralSettings() {
     });
   });
   (document.getElementById('zone-add') as HTMLButtonElement).addEventListener('click', async () => {
-    cfg.zones.push({ id: `zone_${Date.now()}`, name: `Zone ${cfg.zones.length + 1}`, color: '#ffffff' });
+    cfg.zones.push({ id: `zone_${Date.now()}`, name: `Zone ${cfg.zones.length + 1}`, color: 'var(--panel)' });
     await saveConfig({ zones: cfg.zones });
     document.dispatchEvent(new Event('config-changed'));
     renderGeneralSettings();
@@ -359,6 +367,22 @@ function renderGeneralSettings() {
 function renderDisplaySettings() {
   const cfg = getThemeConfig();
   const el = document.getElementById('display-settings')!;
+  const makeCard = (p: ThemePreset, name: string, sel: string) => `
+    <label class="preset-card">
+      <input type="radio" name="${name}" value="${p.id}"${sel===p.id?' checked':''}>
+      <div class="swatches">
+        <span class="swatch" style="background:${p.tokens.bg}"></span>
+        <span class="swatch" style="background:${p.tokens.panel}"></span>
+        <span class="swatch" style="background:${p.tokens.text}"></span>
+        <span class="swatch" style="background:${p.tokens.accent}"></span>
+      </div>
+      <div class="preset-meta">
+        <span>${p.label}</span>
+        ${p.note?`<span class="muted">${p.note}</span>`:''}
+      </div>
+    </label>`;
+  const lightCards = THEME_PRESETS.filter(p=>p.mode==='light').map(p=>makeCard(p,'ds-light',cfg.lightPreset)).join('');
+  const darkCards = THEME_PRESETS.filter(p=>p.mode==='dark').map(p=>makeCard(p,'ds-dark',cfg.darkPreset)).join('');
   el.innerHTML = `
     <section class="panel">
       <h3>Display</h3>
@@ -373,39 +397,67 @@ function renderDisplaySettings() {
           <label><input type="radio" name="ds-mode" value="dark"${cfg.mode==='dark'?' checked':''}> Dark</label>
         </div>
       </div>
-      <div class="form-row">
-        <label>Light preset
-          <select id="ds-light">
-            <option value="paper"${cfg.lightPreset==='paper'?' selected':''}>Paper</option>
-            <option value="fog"${cfg.lightPreset==='fog'?' selected':''}>Fog</option>
-            <option value="pearl"${cfg.lightPreset==='pearl'?' selected':''}>Pearl</option>
-          </select>
-        </label>
-      </div>
-      <div class="form-row">
-        <label>Dark preset
-          <select id="ds-dark">
-            <option value="ink"${cfg.darkPreset==='ink'?' selected':''}>Ink</option>
-            <option value="midnight"${cfg.darkPreset==='midnight'?' selected':''}>Midnight</option>
-            <option value="plum"${cfg.darkPreset==='plum'?' selected':''}>Plum</option>
-          </select>
-        </label>
-      </div>
+      <h4>Light presets</h4>
+      <div class="preset-grid">${lightCards}</div>
+      <div class="form-row"><span id="light-contrast" class="muted"></span></div>
+      <h4>Dark presets</h4>
+      <div class="preset-grid">${darkCards}</div>
+      <div class="form-row"><span id="dark-contrast" class="muted"></span></div>
       <div class="form-row"><label><input type="checkbox" id="ds-contrast"${cfg.highContrast?' checked':''}> High contrast</label></div>
       <div class="form-row"><label><input type="checkbox" id="ds-compact"${cfg.compact?' checked':''}> Compact mode</label></div>
-      <div class="form-row"><button id="ds-save" class="btn">Save Display</button></div>
+      <div class="btn-row"><button id="ds-reset" class="btn">Reset to defaults</button><button id="ds-save" class="btn">Save Display</button></div>
     </section>
   `;
+
+  const contrast = (fg: string, bg: string) => {
+    const hex = (h: string) => {
+      const c = h.replace('#', '');
+      const bigint = parseInt(c, 16);
+      const r = (bigint >> 16) & 255;
+      const g = (bigint >> 8) & 255;
+      const b = bigint & 255;
+      const toLum = (v: number) => {
+        const s = v / 255;
+        return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+      };
+      return 0.2126 * toLum(r) + 0.7152 * toLum(g) + 0.0722 * toLum(b);
+    };
+    const L1 = hex(fg);
+    const L2 = hex(bg);
+    return (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05);
+  };
+
+  const updateContrast = () => {
+    const lightId = (document.querySelector('input[name="ds-light"]:checked') as HTMLInputElement).value;
+    const darkId = (document.querySelector('input[name="ds-dark"]:checked') as HTMLInputElement).value;
+    const lp = THEME_PRESETS.find(p=>p.id===lightId)!;
+    const dp = THEME_PRESETS.find(p=>p.id===darkId)!;
+    const lr = contrast(lp.tokens.text, lp.tokens.bg);
+    const dr = contrast(dp.tokens.text, dp.tokens.bg);
+    (document.getElementById('light-contrast') as HTMLElement).textContent = `Contrast ${lr.toFixed(2)}:1 ${lr>=4.5?'AA pass':'fail'}`;
+    (document.getElementById('dark-contrast') as HTMLElement).textContent = `Contrast ${dr.toFixed(2)}:1 ${dr>=4.5?'AA pass':'fail'}`;
+    const saveBtn = document.getElementById('ds-save') as HTMLButtonElement;
+    saveBtn.disabled = lr < 4.5 || dr < 4.5;
+  };
+  el.querySelectorAll('input[name="ds-light"],input[name="ds-dark"]').forEach((i) => i.addEventListener('change', updateContrast));
+  updateContrast();
+
   document.getElementById('ds-save')!.addEventListener('click', async () => {
     const scale = parseFloat((document.getElementById('ds-scale') as HTMLInputElement).value);
-    const mode = (document.querySelector('input[name="ds-mode"]:checked') as HTMLInputElement).value as any;
-    const lightPreset = (document.getElementById('ds-light') as HTMLSelectElement).value as any;
-    const darkPreset = (document.getElementById('ds-dark') as HTMLSelectElement).value as any;
+    const mode = (document.querySelector('input[name="ds-mode"]:checked') as HTMLInputElement).value as UIMode;
+    const lightPreset = (document.querySelector('input[name="ds-light"]:checked') as HTMLInputElement).value;
+    const darkPreset = (document.querySelector('input[name="ds-dark"]:checked') as HTMLInputElement).value;
     const highContrast = (document.getElementById('ds-contrast') as HTMLInputElement).checked;
     const compact = (document.getElementById('ds-compact') as HTMLInputElement).checked;
     await saveThemeConfig({ scale, mode, lightPreset, darkPreset, highContrast, compact });
     applyTheme();
     alert('Display settings saved.');
+  });
+
+  document.getElementById('ds-reset')!.addEventListener('click', async () => {
+    await saveThemeConfig({ custom: undefined });
+    applyTheme();
+    alert('Theme reset to preset defaults.');
   });
 }
 

--- a/src/utils/zones.ts
+++ b/src/utils/zones.ts
@@ -18,7 +18,7 @@ export function normalizeZones(input: any[]): ZoneDef[] {
       return {
         id: z.toLowerCase().replace(/\s+/g, '_'),
         name: z,
-        color: '#ffffff',
+        color: 'var(--panel)',
         pct: false,
       };
     } else if (typeof z === 'object' && z !== null) {
@@ -26,14 +26,14 @@ export function normalizeZones(input: any[]): ZoneDef[] {
       return {
         id: (z.id ?? name).toLowerCase().replace(/\s+/g, '_'),
         name,
-        color: z.color ?? '#ffffff',
+        color: z.color ?? 'var(--panel)',
         pct: !!(z as any).pct,
       };
     } else {
       return {
         id: `zone_${i}`,
         name: `Zone ${i + 1}`,
-        color: '#ffffff',
+        color: 'var(--panel)',
         pct: false,
       };
     }


### PR DESCRIPTION
## Summary
- add light and dark theme presets with full token sets
- preview presets in settings with contrast checks and reset
- remove hard-coded hex colors in zone defaults

## Testing
- ⚠️ `npm test` (network error shown, tests passed)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1e2f597008327b2c0ed77d3b36c78