### PR TITLE
Require API key header for PHP API and add auth test

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ SetEnv HEYBRE_API_KEY "REPLACE_WITH_RANDOM_LONG_STRING"
 SetEnv HEYBRE_DATA_DIR "/home/<cpanel-user>/heybre-board-data"
 ```
 
+- Clients must send an `X-API-Key` header matching `HEYBRE_API_KEY`.
 - Make sure the data path is writable by PHP.
 - Validate with:
   - `GET https://board.heybre.com/api.php?res=staff`

--- a/server/api.php
+++ b/server/api.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * StaffBoard API (cPanel-safe, file-backed JSON store)
  * - Data directory: /data (auto-created)
  * - Keys: roster.json, config.json, active.json, history.json
+ * - Auth: send `X-API-Key` header matching `HEYBRE_API_KEY`
  * - Endpoints:
  *   ?action=load&key=roster|config|active[&date=YYYY-MM-DD&shift=day|night]
  *   ?action=save&key=roster|config|active[&appendHistory=true]   (POST JSON)
@@ -76,6 +77,12 @@ function activePath(string $dataDir, ?string $date, ?string $shift): string {
   $dateOk  = $date && preg_match('/^\d{4}-\d{2}-\d{2}$/', $date);
   $shiftOk = $shift === 'day' || $shift === 'night';
   return ($dateOk && $shiftOk) ? "$dataDir/active-$date-$shift.json" : "$dataDir/active.json";
+}
+
+$API_KEY = getenv('HEYBRE_API_KEY') ?: '';
+$REQ_KEY = $_SERVER['HTTP_X_API_KEY'] ?? '';
+if ($API_KEY === '' || $REQ_KEY !== $API_KEY) {
+  bad('unauthorized', 401);
 }
 
 /* ---------- router ---------- */

--- a/tests/api-auth.spec.ts
+++ b/tests/api-auth.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+
+let server: ChildProcess;
+
+beforeAll(async () => {
+  server = spawn('php', ['-S', '127.0.0.1:8020', '-t', 'server'], {
+    env: { ...process.env, HEYBRE_API_KEY: 'test-key' },
+    stdio: 'ignore',
+  });
+  await new Promise((resolve) => setTimeout(resolve, 500));
+});
+
+afterAll(() => {
+  server.kill();
+});
+
+describe('API auth', () => {
+  it('rejects missing key', async () => {
+    const res = await fetch('http://127.0.0.1:8020/api.php?action=ping');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects wrong key', async () => {
+    const res = await fetch('http://127.0.0.1:8020/api.php?action=ping', {
+      headers: { 'X-API-Key': 'wrong' },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+


### PR DESCRIPTION
## Summary
- enforce `X-API-Key` header against `HEYBRE_API_KEY` in PHP API
- document API key usage in README and server comments
- add integration test ensuring unauthorized requests receive 401

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e45356488327aca92c505f43c580