### PR TITLE
feat(types): refine server api typings

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -184,7 +184,7 @@ export function getConfig(): Config {
 
 export async function loadConfig(): Promise<Config> {
   try {
-    const cfg = (await Server.load('config')) as Config;
+    const cfg = await Server.load('config');
     CONFIG_CACHE = cfg;
     await DB.set(KS.CONFIG, CONFIG_CACHE);
   } catch {
@@ -343,7 +343,7 @@ export const KS = {
 
 export async function loadStaff(): Promise<Staff[]> {
   try {
-    const remote = (await Server.load('roster')) as Staff[];
+    const remote = await Server.load('roster');
     await DB.set(KS.STAFF, remote);
   } catch {}
   const list = (await DB.get<Staff[]>(KS.STAFF)) || [];

--- a/src/types/server.d.ts
+++ b/src/types/server.d.ts
@@ -1,10 +1,70 @@
+import type { Config, Staff, ActiveBoard } from '@/state';
+import type { PublishedShiftSnapshot } from '@/state/history';
+
 export {};
 
 declare global {
+  interface HistoryQueryList {
+    mode: 'list';
+    date: string;
+  }
+  interface HistoryQueryByNurse {
+    mode: 'byNurse';
+    nurseId: string;
+  }
+  type HistoryQuery = HistoryQueryList | HistoryQueryByNurse;
+
   interface ServerAPI {
-    load(key: 'config' | 'roster' | 'active' | 'history', params?: Record<string, string>): Promise<any>;
-    save(key: 'config' | 'roster' | 'active', payload: any): Promise<any>;
-    softDeleteStaff(id: string): Promise<any>;
+    /**
+     * Load persisted configuration.
+     * @example
+     * const cfg = await Server.load('config');
+     */
+    load(key: 'config'): Promise<Config>;
+    /**
+     * Load the staff roster.
+     * @example
+     * const staff = await Server.load('roster');
+     * staff[0].id;
+     */
+    load(key: 'roster'): Promise<Staff[]>;
+    /**
+     * Load an active board snapshot.
+     * @example
+     * const board = await Server.load('active', { date: '2024-01-01', shift: 'day' });
+     */
+    load(key: 'active', params?: { date?: string; shift?: 'day' | 'night' }): Promise<ActiveBoard | undefined>;
+    /**
+     * Query published history snapshots.
+     * @example
+     * const hist = await Server.load('history', { mode: 'list', date: '2024-01-01' });
+     */
+    load(key: 'history', params: HistoryQuery): Promise<PublishedShiftSnapshot[]>;
+
+    /**
+     * Persist configuration.
+     * @example
+     * await Server.save('config', cfg);
+     */
+    save(key: 'config', payload: Config): Promise<void>;
+    /**
+     * Persist the staff roster.
+     * @example
+     * await Server.save('roster', staff);
+     */
+    save(key: 'roster', payload: Staff[]): Promise<void>;
+    /**
+     * Persist the active board.
+     * @example
+     * await Server.save('active', board);
+     */
+    save(
+      key: 'active',
+      payload: ActiveBoard,
+      params?: { appendHistory?: boolean }
+    ): Promise<void>;
+
+    softDeleteStaff(id: string): Promise<void>;
     exportHistoryCSV(filters?: { from?: string; to?: string; nurseId?: string }): void;
   }
   const Server: ServerAPI;

--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -1,4 +1,5 @@
 import { STATE, getConfig, DB, KS, getActiveBoardCache } from '@/state';
+import type { ActiveBoard } from '@/state';
 import { getThemeConfig, saveThemeConfig, applyTheme } from '@/state/theme';
 import { deriveShift, fmtLong } from '@/utils/time';
 import { manualHandoff, renderAll } from '@/main';
@@ -82,7 +83,10 @@ export function renderHeader() {
           await Server.save('active', local);
         } catch {}
       }
-      const board = await Server.load('active', { date: dateISO, shift });
+      const board: ActiveBoard | undefined = await Server.load('active', {
+        date: dateISO,
+        shift,
+      });
       if (board) await DB.set(KS.ACTIVE(dateISO, shift), board);
       await renderAll();
       showBanner('Refreshed');


### PR DESCRIPTION
## Summary
- add typed server API with examples for config, roster, active board, and history
- rely on typed server methods across state and UI modules

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1e44f7e9c83278a0f04bae9e49c32