### PR TITLE
refactor: isolate debounced save timers

### DIFF
--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -18,7 +18,7 @@ import { setNurseCache, labelFromId } from '@/utils/names';
 import { renderWeather } from './widgets';
 import { renderPhysicians } from './physicians';
 import { nurseTile } from './nurseTile';
-import { debouncedSave } from '@/utils/debouncedSave';
+import { createDebouncer } from '@/utils/debouncedSave';
 import './mainBoard/boardLayout.css';
 import { startBreak, endBreak, moveSlot, upsertSlot, removeSlot, type Slot } from '@/slots';
 import { canonNurseType } from '@/domain/lexicon';
@@ -381,14 +381,14 @@ function wireComments(active: ActiveBoard, save: () => void) {
     save();
   };
 
-  el.addEventListener('input', () =>
-    debouncedSave(
-      () => {
-        active.comments = el.value;
-      },
-      () => save()
-    )
+  const debounced = createDebouncer(
+    () => {
+      active.comments = el.value;
+    },
+    () => save()
   );
+
+  el.addEventListener('input', debounced);
 
   el.addEventListener('blur', commit);
 }

--- a/src/utils/debouncedSave.ts
+++ b/src/utils/debouncedSave.ts
@@ -1,7 +1,13 @@
-let saveTimer: number | undefined;
-
-/** Debounce a save function to reduce rapid writes. */
-export function debouncedSave<T>(fn: () => T, commit: (v: T) => void, ms = 500): void {
-  if (saveTimer) window.clearTimeout(saveTimer);
-  saveTimer = window.setTimeout(() => commit(fn()), ms);
+/** Create a debounced function with its own timer. */
+export function createDebouncer<T>(
+  fn: () => T,
+  commit: (v: T) => void,
+  ms = 500
+): () => void {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return () => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => commit(fn()), ms);
+  };
 }
+

--- a/tests/debouncedSave.spec.ts
+++ b/tests/debouncedSave.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createDebouncer } from '@/utils/debouncedSave';
+
+describe('createDebouncer', () => {
+  it('maintains independent timers', () => {
+    vi.useFakeTimers();
+    const fnA = vi.fn(() => 'a');
+    const commitA = vi.fn();
+    const debA = createDebouncer(fnA, commitA, 100);
+
+    const fnB = vi.fn(() => 'b');
+    const commitB = vi.fn();
+    const debB = createDebouncer(fnB, commitB, 100);
+
+    debA();
+    vi.advanceTimersByTime(50);
+    debB();
+    vi.advanceTimersByTime(60);
+    expect(commitA).toHaveBeenCalledTimes(1);
+    expect(commitB).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(40);
+    expect(commitB).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});
+


### PR DESCRIPTION
## Summary
- replace global save timer with `createDebouncer` factory
- use debouncer for comments in board view
- test multiple debouncers keep independent timers

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1e442be6c8327814d54da4c3c8b02