### PR TITLE
feat: add upcoming physicians popup

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -215,6 +215,9 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .manage-dialog .dialog-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:8px}
 .banner{background:var(--danger);color:var(--text);padding:8px;text-align:center}
 
+.phys-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:var(--z-modal)}
+.phys-modal{background:var(--panel);padding:16px;border-radius:8px;max-width:320px;max-height:80vh;overflow:auto}
+
 .preset-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:8px;margin:8px 0}
 .preset-card{display:flex;flex-direction:column;gap:4px;border:1px solid var(--line);border-radius:8px;padding:6px;background:var(--control)}
 .swatches{display:flex;gap:4px}

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -16,7 +16,7 @@ import {
 } from '@/state';
 import { setNurseCache, labelFromId } from '@/utils/names';
 import { renderWeather } from './widgets';
-import { renderPhysicians } from './physicians';
+import { renderPhysicians, renderPhysicianPopup } from './physicians';
 import { nurseTile } from './nurseTile';
 import { debouncedSave } from '@/utils/debouncedSave';
 import './mainBoard/boardLayout.css';
@@ -118,6 +118,7 @@ export async function renderBoard(
           <section class="panel">
             <h3>Physicians (read-only)</h3>
             <div id="phys"></div>
+            <button id="phys-next7" class="btn">Next 7 days</button>
           </section>
         </div>
       </div>
@@ -143,6 +144,11 @@ export async function renderBoard(
       document.getElementById('phys') as HTMLElement,
       ctx.dateISO
     );
+
+    const btn = document.getElementById('phys-next7');
+    btn?.addEventListener('click', () => {
+      renderPhysicianPopup(ctx.dateISO, 7);
+    });
 
     // Removed testBoardFit call; allow natural scroll for overflow
 

--- a/tests/physicians.spec.ts
+++ b/tests/physicians.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { __test } from '@/ui/physicians';
+import { vi } from 'vitest';
+import { __test, getUpcomingDoctors } from '@/ui/physicians';
 
 describe('physician schedule parsing', () => {
   it('extracts events from ICS', () => {
@@ -24,5 +25,43 @@ describe('physician schedule parsing', () => {
       summary: 'Dr A',
       location: 'Jewish Downtown',
     });
+  });
+
+  it('groups upcoming physicians by date', async () => {
+    const sample = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'DTSTART:20240101T070000',
+      'SUMMARY:Dr A',
+      'LOCATION:Jewish Downtown',
+      'END:VEVENT',
+      'BEGIN:VEVENT',
+      'DTSTART:20240105T070000',
+      'SUMMARY:Dr B',
+      'LOCATION:Jewish Downtown',
+      'END:VEVENT',
+      'BEGIN:VEVENT',
+      'DTSTART:20240108T070000',
+      'SUMMARY:Dr C',
+      'LOCATION:Jewish Downtown',
+      'END:VEVENT',
+      'BEGIN:VEVENT',
+      'DTSTART:20240103T070000',
+      'SUMMARY:Dr D',
+      'LOCATION:Other',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\n');
+    const original = (global as any).fetch;
+    (global as any).fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(sample),
+    });
+    const res = await getUpcomingDoctors('2024-01-01', 7);
+    expect(res).toEqual({
+      '2024-01-01': ['Dr A'],
+      '2024-01-05': ['Dr B'],
+    });
+    (global as any).fetch = original;
   });
 });


### PR DESCRIPTION
## Summary
- add “Next 7 days” button and trigger for physicians panel
- implement helpers to fetch upcoming doctors and show popup dialog
- style popup and test upcoming doctor filtering

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1e4a2fab08327b67a1fb23aa609a9