### PR TITLE
docs: add JSDoc for utils and history

### DIFF
--- a/src/history/CalendarView.ts
+++ b/src/history/CalendarView.ts
@@ -21,7 +21,11 @@ function isPublishedShiftSnapshot(obj: any): obj is PublishedShiftSnapshot {
   );
 }
 
-/** Render the calendar-based history view with listing, saving, and export. */
+/**
+ * Render the calendar-based history view with listing, saving, and export.
+ * @param root element to populate
+ * @returns nothing
+ */
 export function renderCalendarView(root: HTMLElement): void {
   root.innerHTML = `
     <div class="history-calendar">

--- a/src/history/HuddleTable.ts
+++ b/src/history/HuddleTable.ts
@@ -2,7 +2,11 @@ import { listHuddles, type HuddleRecord } from '@/state/history';
 import { exportHuddlesCSV } from '@/history';
 import './history.css';
 
-/** Render table of saved huddle records. */
+/**
+ * Render table of saved huddle records.
+ * @param root element to populate
+ * @returns nothing
+ */
 export function renderHuddleTable(root: HTMLElement): void {
   root.innerHTML = `
     <div class="history-huddles">

--- a/src/history/NurseHistory.ts
+++ b/src/history/NurseHistory.ts
@@ -3,7 +3,11 @@ import { findShiftsByStaff } from '@/state/history';
 import { exportNurseHistoryCSV } from '@/history';
 import './history.css';
 
-/** Render the nurse-centric history search view. */
+/**
+ * Render the nurse-centric history search view.
+ * @param root element to populate
+ * @returns nothing
+ */
 export function renderNurseHistory(root: HTMLElement): void {
   root.innerHTML = `
     <div class="history-nurse">

--- a/src/history/index.ts
+++ b/src/history/index.ts
@@ -8,7 +8,11 @@ import type {
   HuddleRecord,
 } from '@/state/history';
 
-/** Render History tab with sub-views. */
+/**
+ * Render History tab with sub-views.
+ * @param root element to populate
+ * @returns nothing
+ */
 export function renderHistory(root: HTMLElement): void {
   root.innerHTML = `
     <div class="history-nav">
@@ -35,7 +39,11 @@ export function renderHistory(root: HTMLElement): void {
   show('calendar');
 }
 
-/** Export a single shift snapshot to CSV. */
+/**
+ * Export a single shift snapshot to CSV.
+ * @param snapshot shift snapshot to serialize
+ * @returns CSV string
+ */
 export function exportShiftCSV(snapshot: PublishedShiftSnapshot): string {
   const header = 'date,shift,zone,staffId,displayName,role,startISO,endISO,dto';
   const rows = snapshot.zoneAssignments
@@ -56,7 +64,11 @@ export function exportShiftCSV(snapshot: PublishedShiftSnapshot): string {
   return `${header}\n${rows}`;
 }
 
-/** Export nurse history entries to CSV. */
+/**
+ * Export nurse history entries to CSV.
+ * @param entries list of nurse history rows
+ * @returns CSV string
+ */
 export function exportNurseHistoryCSV(entries: NurseShiftIndexEntry[]): string {
   const header = 'staffId,displayName,role,date,shift,zone,startISO,endISO,dto';
   const rows = entries
@@ -77,7 +89,11 @@ export function exportNurseHistoryCSV(entries: NurseShiftIndexEntry[]): string {
   return `${header}\n${rows}`;
 }
 
-/** Export huddle records to CSV. */
+/**
+ * Export huddle records to CSV.
+ * @param records saved huddle records
+ * @returns CSV string
+ */
 export function exportHuddlesCSV(records: HuddleRecord[]): string {
   const header = 'date,shift,recordedAt,recordedBy,notes';
   const rows = records

--- a/src/utils/debouncedSave.ts
+++ b/src/utils/debouncedSave.ts
@@ -1,6 +1,12 @@
 let saveTimer: number | undefined;
 
-/** Debounce a save function to reduce rapid writes. */
+/**
+ * Debounce a save function to reduce rapid writes.
+ * @param fn producer to run
+ * @param commit callback with produced value
+ * @param ms delay before commit
+ * @returns nothing
+ */
 export function debouncedSave<T>(fn: () => T, commit: (v: T) => void, ms = 500): void {
   if (saveTimer) window.clearTimeout(saveTimer);
   saveTimer = window.setTimeout(() => commit(fn()), ms);

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,3 +1,7 @@
+/**
+ * Outline full-screen blocking elements for debugging.
+ * @returns nothing
+ */
 export function outlineBlockers(): void {
   const els = Array.from(document.querySelectorAll<HTMLElement>('body *'));
   els.forEach((el) => {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,3 +1,8 @@
+/**
+ * Format date to MM/DD/YYYY string.
+ * @param d date input
+ * @returns formatted date
+ */
 export function formatDateUS(d: Date | string | number) {
   const dt = new Date(d);
   const mm = String(dt.getMonth() + 1).padStart(2, '0');
@@ -5,6 +10,12 @@ export function formatDateUS(d: Date | string | number) {
   const yyyy = dt.getFullYear();
   return `${mm}/${dd}/${yyyy}`;
 }
+
+/**
+ * Format time in 24h HH:MM for Louisville zone.
+ * @param d date input
+ * @returns formatted time
+ */
 export function formatTime24h(d: Date | string | number) {
   return new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/Kentucky/Louisville',

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,8 +1,17 @@
+/**
+ * Generate a prefixed staff id.
+ * @returns new staff id
+ */
 export function createStaffId(): string {
   const uuid = crypto.randomUUID();
   return `00-${uuid}`;
 }
 
+/**
+ * Ensure id uses staff prefix.
+ * @param id raw identifier
+ * @returns normalized id
+ */
 export function ensureStaffId(id: string): string {
   return id.startsWith('00-') ? id : `00-${id}`;
 }

--- a/src/utils/names.ts
+++ b/src/utils/names.ts
@@ -4,15 +4,19 @@ import { getConfig } from '@/state';
 let NURSES: Staff[] = [];
 
 /**
- * Set the in-memory nurse cache.
+ * Store staff list for lookup helpers.
+ * @param list staff records to cache
+ * @returns nothing
  */
 export function setNurseCache(list: Staff[]): void {
   NURSES = Array.isArray(list) ? [...list] : [];
 }
 
 /**
- * Format a short name from a full name.
- * Returns "First L." given "First Last".
+ * Build a short name from a full name.
+ * @param full full name to format
+ * @param privacy hide last name when true
+ * @returns formatted name
  */
 export function formatName(full: string, privacy = true): string {
   const parts = (full || '').trim().split(/\s+/).filter(Boolean);
@@ -23,27 +27,37 @@ export function formatName(full: string, privacy = true): string {
 }
 
 /**
- * Convenience wrapper for privacy-on short names.
+ * Generate privacy-on short name.
+ * @param full full name to format
+ * @returns formatted name
  */
 export function formatShortName(full: string): string {
   return formatName(full, true);
 }
 
+/**
+ * Format name respecting configuration privacy.
+ * @param full full name to format
+ * @returns display name
+ */
 export function formatDisplayName(full: string): string {
   const cfg = getConfig();
   return formatName(full, cfg.privacy !== false);
 }
 
 /**
- * Retrieve a nurse by id from the cache.
+ * Look up nurse in cache by id.
+ * @param id nurse identifier
+ * @returns matching staff or undefined
  */
 export function getNurseById(id: string): Staff | undefined {
   return NURSES.find((n) => n.id === id);
 }
 
 /**
- * Get a display label for a nurse id.
- * Falls back to empty string if the nurse is not found.
+ * Resolve display label for nurse id.
+ * @param id nurse identifier
+ * @returns short label or empty string
  */
 export function labelFromId(id?: string): string {
   if (!id) return '';

--- a/src/utils/role.ts
+++ b/src/utils/role.ts
@@ -1,7 +1,11 @@
 /** Allowed user roles. */
 export type Role = 'nurse' | 'tech';
 
-/** Ensure a user object has a valid role. */
+/**
+ * Ensure a user object has a valid role.
+ * @param u user object to check
+ * @returns nothing
+ */
 export function ensureRole(u: { role: string }): asserts u is { role: Role } {
   if (u.role !== 'nurse' && u.role !== 'tech') {
     throw new Error(`Invalid role: ${u.role}`);

--- a/src/utils/shiftCodes.ts
+++ b/src/utils/shiftCodes.ts
@@ -1,5 +1,12 @@
-export type ShiftSchedule = { dayStart: string; nightStart: string }; // "07:00", "19:00"
+/** Shift start times in HH:MM. */
+export type ShiftSchedule = { dayStart: string; nightStart: string };
 
+/**
+ * Generate compact shift code like YYYYMMDD-D/N.
+ * @param d date to encode
+ * @param sched shift start times
+ * @returns formatted code
+ */
 export function generateShiftCode(
   d: Date,
   sched: ShiftSchedule = { dayStart: '07:00', nightStart: '19:00' }
@@ -14,6 +21,12 @@ export function generateShiftCode(
   return `${y}${m}${day}-${isDay ? 'D' : 'N'}`;
 }
 
+/**
+ * Determine upcoming shift window from current time.
+ * @param now reference time
+ * @param sched shift schedule
+ * @returns start and end ISO strings plus label
+ */
 export function nextShiftWindow(
   now = new Date(),
   sched: ShiftSchedule = { dayStart: '07:00', nightStart: '19:00' }

--- a/src/utils/staff.ts
+++ b/src/utils/staff.ts
@@ -1,5 +1,12 @@
 import type { Staff } from "../state";
 
+/**
+ * Check if an employee id is unique in a list.
+ * @param staff staff array to search
+ * @param id id to validate
+ * @param existingId ignore this id when editing
+ * @returns true if id is unique
+ */
 export function isEmployeeIdUnique(
   staff: Staff[],
   id: string,

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,9 +1,19 @@
+/** Day or night shift label. */
 export type Shift = "day" | "night";
 
+/**
+ * Pad number to two digits.
+ * @param n number to format
+ * @returns zero-padded string
+ */
 export function pad2(n: number): string {
   return n.toString().padStart(2, "0");
 }
 
+/**
+ * Get current time in HH:MM local format.
+ * @returns formatted time string
+ */
 export function hhmmNowLocal(): string {
   const d = new Date();
   return `${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
@@ -14,10 +24,17 @@ function toMinutes(hhmm: string): number {
   return h * 60 + m;
 }
 
+/**
+ * Determine shift from clock time.
+ * @param hhmm time string in HH:MM
+ * @param dayAnchor day shift start
+ * @param nightAnchor night shift start
+ * @returns shift label
+ */
 export function deriveShift(
   hhmm: string,
   dayAnchor = "07:00",
-  nightAnchor = "19:00"
+  nightAnchor = "19:00",
 ): Shift {
   const t = toMinutes(hhmm);
   const dayStart = toMinutes(dayAnchor);
@@ -31,9 +48,15 @@ export function deriveShift(
   }
 }
 
+/**
+ * Compute next shift given a date and current shift.
+ * @param dateISO base date in ISO format
+ * @param shift current shift label
+ * @returns tuple with next shift info
+ */
 export function nextShiftTuple(
   dateISO: string,
-  shift: Shift
+  shift: Shift,
 ): { dateISO: string; shift: Shift } {
   if (shift === "day") {
     return { dateISO, shift: "night" };
@@ -43,10 +66,20 @@ export function nextShiftTuple(
   return { dateISO: toDateISO(d), shift: "day" };
 }
 
+/**
+ * Convert Date to YYYY-MM-DD string.
+ * @param date date object to format
+ * @returns ISO date string
+ */
 export function toDateISO(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
+/**
+ * Format ISO date to long human string.
+ * @param dateISO date in YYYY-MM-DD format
+ * @returns locale date string
+ */
 export function fmtLong(dateISO: string): string {
   const d = new Date(`${dateISO}T00:00:00`);
   return d.toLocaleDateString(undefined, {

--- a/src/utils/zones.ts
+++ b/src/utils/zones.ts
@@ -7,8 +7,9 @@ export interface ZoneDef {
 }
 
 /**
- * Normalize zones into a consistent array of { id, name, color }.
- * Accepts either string[] or object[] from config.json.
+ * Normalize zones into { id, name, color } objects.
+ * @param input raw config zone list
+ * @returns normalized zone definitions
  */
 export function normalizeZones(input: any[]): ZoneDef[] {
   if (!Array.isArray(input)) return [];
@@ -42,7 +43,9 @@ export function normalizeZones(input: any[]): ZoneDef[] {
 
 /**
  * Ensure active.zones keys align with normalized zone names.
- * Mutates the active object in place.
+ * @param active active board object
+ * @param zones normalized zones
+ * @returns nothing
  */
 export function normalizeActiveZones(active: any, zones: ZoneDef[]): void {
   if (!active || typeof active !== 'object') return;


### PR DESCRIPTION
## Summary
- document name formatting helpers
- annotate time utilities and shift code helpers
- clarify history rendering and CSV exports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e459fde083278ffb7a2d43fc922a