### PR TITLE
refactor: tighten types and generics

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -27,7 +27,7 @@ export async function get<T>(key: string): Promise<T | undefined> {
   });
 }
 
-export async function set(key: string, val: any): Promise<void> {
+export async function set<T>(key: string, val: T): Promise<void> {
   const db = await openDB();
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE, "readwrite");
@@ -56,8 +56,10 @@ export async function keys(prefix = ""): Promise<string[]> {
     const store = tx.objectStore(STORE);
     const req = store.getAllKeys();
     req.onsuccess = () => {
-      const all: string[] = req.result as any;
-      resolve(all.filter((k) => k.startsWith(prefix)));
+      const all = req.result as IDBValidKey[];
+      resolve(
+        (all as string[]).filter((k) => typeof k === 'string' && k.startsWith(prefix))
+      );
     };
     req.onerror = () => reject(req.error);
   });

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -194,10 +194,14 @@ export async function loadConfig(): Promise<Config> {
   return mergeConfigDefaults();
 }
 
-export async function saveConfig(partial: Partial<Config>): Promise<Config> {
+export async function saveConfig(
+  partial: Partial<Omit<Config, 'zones'>> & {
+    zones?: Array<string | Partial<ZoneDef>>;
+  }
+): Promise<Config> {
   const updated: Config = { ...CONFIG_CACHE, ...partial } as Config;
   if (partial.zones) {
-    updated.zones = normalizeZones(partial.zones as any);
+    updated.zones = normalizeZones(partial.zones);
   }
   CONFIG_CACHE = updated;
   mergeConfigDefaults();
@@ -239,7 +243,7 @@ export function mergeConfigDefaults(): Config {
 
   // Normalize zones & flag validity
   try {
-    const normalized = normalizeZones((cfg.zones as any) ?? []);
+    const normalized = normalizeZones(cfg.zones ?? []);
     // Apply color overrides
     for (const z of normalized) {
       if (cfg.zoneColors && cfg.zoneColors[z.name]) z.color = cfg.zoneColors[z.name];
@@ -305,28 +309,33 @@ export function mergeConfigDefaults(): Config {
   return CONFIG_CACHE;
 }
 
-export function migrateActiveBoard(raw: any): ActiveBoard {
-  const zones = raw?.zones && typeof raw.zones === 'object' ? raw.zones : {};
+export function migrateActiveBoard(raw: unknown): ActiveBoard {
+  const r = raw as Partial<ActiveBoard> | undefined;
+  const zones = r?.zones && typeof r.zones === 'object' ? r.zones : {};
   return {
-    dateISO: raw?.dateISO ?? toDateISO(new Date()),
-    shift: raw?.shift === 'night' ? 'night' : 'day',
-    charge: raw?.charge ?? undefined,
-    triage: raw?.triage ?? undefined,
-    admin: raw?.admin ?? undefined,
+    dateISO: r?.dateISO ?? toDateISO(new Date()),
+    shift: r?.shift === 'night' ? 'night' : 'day',
+    charge: r?.charge ?? undefined,
+    triage: r?.triage ?? undefined,
+    admin: r?.admin ?? undefined,
     zones: Object.fromEntries(
-      Object.entries(zones).map(([k, v]) => [k, Array.isArray(v) ? v : []])
+      Object.entries(zones).map(([k, v]) => [k, Array.isArray(v) ? (v as Slot[]) : []])
     ),
-    incoming: Array.isArray(raw?.incoming)
-      ? raw.incoming.filter((i: any) => typeof i?.nurseId === 'string')
-      : [],
-    offgoing: Array.isArray(raw?.offgoing)
-      ? raw.offgoing.filter(
-          (o: any) => typeof o?.nurseId === 'string' && typeof o?.ts === 'number'
+    incoming: Array.isArray(r?.incoming)
+      ? r.incoming.filter(
+          (i): i is ActiveBoard['incoming'][number] =>
+            typeof i?.nurseId === 'string'
         )
       : [],
-    comments: typeof raw?.comments === 'string' ? raw.comments : '',
-    huddle: typeof raw?.huddle === 'string' ? raw.huddle : '',
-    handoff: typeof raw?.handoff === 'string' ? raw.handoff : '',
+    offgoing: Array.isArray(r?.offgoing)
+      ? r.offgoing.filter(
+          (o): o is ActiveBoard['offgoing'][number] =>
+            typeof o?.nurseId === 'string' && typeof o?.ts === 'number'
+        )
+      : [],
+    comments: typeof r?.comments === 'string' ? r.comments : '',
+    huddle: typeof r?.huddle === 'string' ? r.huddle : '',
+    handoff: typeof r?.handoff === 'string' ? r.handoff : '',
     version: CURRENT_SCHEMA_VERSION,
   };
 }
@@ -351,7 +360,7 @@ export async function loadStaff(): Promise<Staff[]> {
   const normalized = list.map((s) => {
     ensureRole(s);
     const id = ensureStaffId(s.id);
-    const rawType = (s as any).type;
+    const rawType = (s as { type?: string | null }).type;
     const type = (canonNurseType(rawType) || rawType || 'home') as NurseType;
     if (id !== s.id) changed = true;
     return { ...s, id, type } as Staff;

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -8,11 +8,12 @@ import {
   STATE,
   loadStaff,
   saveStaff,
-  Staff,
-  ActiveBoard,
   CURRENT_SCHEMA_VERSION,
   migrateActiveBoard,
   setActiveBoardCache,
+  type Staff,
+  type ActiveBoard,
+  type Config,
 } from '@/state';
 import { setNurseCache, labelFromId } from '@/utils/names';
 import { renderWeather } from './widgets';
@@ -21,7 +22,7 @@ import { nurseTile } from './nurseTile';
 import { debouncedSave } from '@/utils/debouncedSave';
 import './mainBoard/boardLayout.css';
 import { startBreak, endBreak, moveSlot, upsertSlot, removeSlot, type Slot } from '@/slots';
-import { canonNurseType } from '@/domain/lexicon';
+import { canonNurseType, type NurseType } from '@/domain/lexicon';
 import { normalizeActiveZones, type ZoneDef } from '@/utils/zones';
 import type { DraftShift } from '@/state';
 
@@ -124,7 +125,7 @@ export async function renderBoard(
     `;
 
     // Debounced save
-    let saveTimer: any;
+    let saveTimer: ReturnType<typeof setTimeout>;
     const queueSave = () => {
       clearTimeout(saveTimer);
       saveTimer = setTimeout(() => {
@@ -259,7 +260,12 @@ function assignLeadDialog(
 
 // --- zones & tiles ---------------------------------------------------------
 
-function renderZones(active: ActiveBoard, cfg: any, staff: Staff[], save: () => void) {
+function renderZones(
+  active: ActiveBoard,
+  cfg: Config,
+  staff: Staff[],
+  save: () => void
+) {
   const pctCont = document.getElementById('pct-zones')!;
   const cont = document.getElementById('zones')!;
   pctCont.innerHTML = '';
@@ -429,7 +435,7 @@ async function renderIncoming(active: ActiveBoard, save: () => void) {
   if (active.incoming.length === 0) {
     cont.innerHTML = '<div class="incoming-placeholder"></div>';
   } else {
-    active.incoming.forEach((inc: any) => {
+    active.incoming.forEach((inc) => {
       const div = document.createElement('div');
       const name = labelFromId(inc.nurseId);
       div.textContent = `${name} ${inc.eta}${inc.arrived ? ' ✓' : ''}`;
@@ -479,7 +485,7 @@ async function renderIncoming(active: ActiveBoard, save: () => void) {
 function renderOffgoing(active: ActiveBoard, save: () => void) {
   const cont = document.getElementById('offgoing')!;
   const cutoff = Date.now() - 60 * 60 * 1000; // 60 min
-  active.offgoing = (active.offgoing || []).filter((o: any) => o.ts > cutoff);
+  active.offgoing = (active.offgoing || []).filter((o) => o.ts > cutoff);
 
   cont.innerHTML = '';
   for (const o of active.offgoing) {
@@ -500,8 +506,8 @@ function manageSlot(
   rerender: () => void,
   zone: string,
   index: number,
-  board: any,
-  cfg: any
+  board: ActiveBoard,
+  cfg: Config
 ): void {
   if (!st) return;
 
@@ -561,7 +567,13 @@ function manageSlot(
     board.offgoing.push({ nurseId: st.id, ts: Date.now() });
 
     // Append to history
-    const hist = (await DB.get<any[]>(KS.HISTORY)) || [];
+    interface HistoryEntry {
+      nurseId: string;
+      dateISO: string;
+      shift: 'day' | 'night';
+      endedISO: string;
+    }
+    const hist = (await DB.get<HistoryEntry[]>(KS.HISTORY)) || [];
     hist.push({
       nurseId: st.id,
       dateISO: board.dateISO,
@@ -588,8 +600,8 @@ function manageSlot(
     // Only nurses have a nurse type
     if (st.role === 'nurse') {
       const tval = (overlay.querySelector('#mg-type') as HTMLSelectElement).value;
-      const canon = canonNurseType(tval) || st.type;
-      st.type = canon as any;
+      const canon = (canonNurseType(tval) || st.type) as NurseType;
+      st.type = canon;
     }
 
     // Slot-level fields

--- a/src/utils/zones.ts
+++ b/src/utils/zones.ts
@@ -10,7 +10,9 @@ export interface ZoneDef {
  * Normalize zones into a consistent array of { id, name, color }.
  * Accepts either string[] or object[] from config.json.
  */
-export function normalizeZones(input: any[]): ZoneDef[] {
+export function normalizeZones(
+  input: Array<string | Partial<ZoneDef>>
+): ZoneDef[] {
   if (!Array.isArray(input)) return [];
 
   return input.map((z, i) => {
@@ -27,7 +29,7 @@ export function normalizeZones(input: any[]): ZoneDef[] {
         id: (z.id ?? name).toLowerCase().replace(/\s+/g, '_'),
         name,
         color: z.color ?? '#ffffff',
-        pct: !!(z as any).pct,
+        pct: Boolean(z.pct),
       };
     } else {
       return {
@@ -44,10 +46,13 @@ export function normalizeZones(input: any[]): ZoneDef[] {
  * Ensure active.zones keys align with normalized zone names.
  * Mutates the active object in place.
  */
-export function normalizeActiveZones(active: any, zones: ZoneDef[]): void {
+export function normalizeActiveZones<T>(
+  active: { zones?: Record<string, T[]> } | undefined,
+  zones: ZoneDef[]
+): void {
   if (!active || typeof active !== 'object') return;
   if (!active.zones || typeof active.zones !== 'object') active.zones = {};
-  const normalized: Record<string, any[]> = {};
+  const normalized: Record<string, T[]> = {};
   for (const z of zones) {
     const arr = active.zones[z.name];
     normalized[z.name] = Array.isArray(arr) ? arr : [];

--- a/tests/types.spec.ts
+++ b/tests/types.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import { normalizeZones, normalizeActiveZones, type ZoneDef } from '@/utils/zones';
+import { set } from '@/db';
+import { migrateActiveBoard, type ActiveBoard } from '@/state';
+
+describe('typed signatures', () => {
+  it('normalizeZones accepts strings and partial objects', () => {
+    const result = normalizeZones(['A', { id: 'b', name: 'B' }]);
+    expectTypeOf(result).toEqualTypeOf<ZoneDef[]>();
+  });
+
+  it('normalizeActiveZones preserves element types', () => {
+    const active = { zones: { A: [{ foo: 'bar' }] } };
+    normalizeActiveZones(active, [{ id: 'a', name: 'A' }]);
+    expectTypeOf(active.zones.A[0]).toEqualTypeOf<{ foo: string }>();
+  });
+
+  it('db.set is generic', () => {
+    expectTypeOf(set).parameter(1).not.toBeAny();
+  });
+
+  it('migrateActiveBoard returns ActiveBoard', () => {
+    const board = migrateActiveBoard({});
+    expectTypeOf(board).toEqualTypeOf<ActiveBoard>();
+  });
+});


### PR DESCRIPTION
## Summary
- replace `any` with typed inputs and generics across zones, state, db, and board modules
- adjust board rendering and management logic to use Config and strongly typed history entries
- add unit tests verifying generic signatures and type preservation

## Testing
- `npm test`
- `npm run build`
- `npm run precheck`


------
https://chatgpt.com/codex/tasks/task_e_68b1e43e9c8083278f310d3c3c029f0f