### PR TITLE
feat: proxy physicians calendar via API

### DIFF
--- a/api.php
+++ b/api.php
@@ -61,6 +61,7 @@ function activePath(string $dataDir, ?string $date, ?string $shift): string {
 $action      = $_GET['action'] ?? '';
 $keyParam    = $_GET['key'] ?? '';
 $historyPath = $DATA_DIR . '/history.json';
+$physiciansUrl = 'https://www.bytebloc.com/sk/?76b6a156';
 
 switch ($action) {
   case 'load': {
@@ -193,6 +194,27 @@ switch ($action) {
       }
     }
     fclose($out);
+    exit;
+  }
+
+  case 'physicians': {
+    header('Content-Type: text/calendar; charset=utf-8');
+    $cachePath = $DATA_DIR . '/physicians.ics';
+    $ttl = 300; // 5 minutes
+    $ics = null;
+    if (is_file($cachePath) && (time() - filemtime($cachePath) < $ttl)) {
+      $ics = @file_get_contents($cachePath);
+    }
+    if ($ics === null) {
+      $ics = @file_get_contents($physiciansUrl);
+      if ($ics === false) {
+        $ics = is_file($cachePath) ? @file_get_contents($cachePath) : null;
+      } else {
+        @file_put_contents($cachePath, $ics);
+      }
+    }
+    if ($ics === null) bad('calendar fetch failed', 502);
+    echo $ics;
     exit;
   }
 

--- a/server/api.php
+++ b/server/api.php
@@ -89,6 +89,7 @@ if ($API_KEY === '' || $REQ_KEY !== $API_KEY) {
 $action = $_GET['action'] ?? '';
 $key    = $_GET['key'] ?? '';
 $historyPath = $DATA_DIR . '/history.json';
+$physiciansUrl = 'https://www.bytebloc.com/sk/?76b6a156';
 
 try {
   ensureRosterExists($DATA_DIR, $ROOT_DIR);
@@ -225,6 +226,27 @@ try {
         }
       }
       fclose($out);
+      exit;
+    }
+
+    case 'physicians': {
+      header('Content-Type: text/calendar; charset=utf-8');
+      $cachePath = $DATA_DIR . '/physicians.ics';
+      $ttl = 300; // 5 minutes
+      $ics = null;
+      if (is_file($cachePath) && (time() - filemtime($cachePath) < $ttl)) {
+        $ics = @file_get_contents($cachePath);
+      }
+      if ($ics === null) {
+        $ics = @file_get_contents($physiciansUrl);
+        if ($ics === false) {
+          $ics = is_file($cachePath) ? @file_get_contents($cachePath) : null;
+        } else {
+          @file_put_contents($cachePath, $ics);
+        }
+      }
+      if ($ics === null) bad('calendar fetch failed', 502);
+      echo $ics;
       exit;
     }
 

--- a/src/ui/physicians.ts
+++ b/src/ui/physicians.ts
@@ -1,5 +1,3 @@
-const CAL_URL = 'https://www.bytebloc.com/sk/?76b6a156';
-
 type Event = {
   date: string;
   summary: string;
@@ -47,7 +45,7 @@ function parseICS(text: string): Event[] {
 /** Fetch and render physicians for the given day. */
 export async function renderPhysicians(el: HTMLElement, dateISO: string): Promise<void> {
   try {
-    const res = await fetch(CAL_URL);
+    const res = await fetch('/api.php?action=physicians');
     if (!res.ok) throw new Error('failed');
     const ics = await res.text();
     const events = parseICS(ics);


### PR DESCRIPTION
## Summary
- add `physicians` API action to fetch external ICS, cached server-side
- update client physicians view to use new same-origin endpoint

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1e5a51c088327b1312a172e155f7a