### PR TITLE
Handle TZID in ICS physician schedule parsing

### DIFF
--- a/src/ui/physicians.ts
+++ b/src/ui/physicians.ts
@@ -35,7 +35,8 @@ function parseICS(text: string): Event[] {
     } else if (current) {
       const idx = line.indexOf(':');
       if (idx > -1) {
-        const key = line.slice(0, idx);
+        const keyRaw = line.slice(0, idx);
+        const key = keyRaw.split(';')[0];
         const value = line.slice(idx + 1);
         current[key] = value;
       }

--- a/tests/physicians.spec.ts
+++ b/tests/physicians.spec.ts
@@ -25,4 +25,23 @@ describe('physician schedule parsing', () => {
       location: 'Jewish Downtown',
     });
   });
+
+  it('handles DTSTART with TZID parameter', () => {
+    const sample = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'DTSTART;TZID=America/New_York:20240101T070000',
+      'SUMMARY:Dr A',
+      'LOCATION:Jewish Downtown',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\n');
+    const events = __test.parseICS(sample);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      date: '2024-01-01',
+      summary: 'Dr A',
+      location: 'Jewish Downtown',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- strip ICS property options such as `;TZID=...` when parsing physician schedules
- add unit test for `DTSTART;TZID=` handling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1e5a3701c8327a0e122d2c46e6021