### PR TITLE
feat: configurable physicians calendar

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -46,6 +46,7 @@ export type Config = {
   dtoMinutes?: number;
   showPinned?: { charge: boolean; triage: boolean };
   rss?: { url: string; enabled: boolean };
+  physicians?: { calendarUrl: string };
   privacy?: boolean;
   ui?: {
     signoutMode?: 'shiftHuddle' | 'disabled' | 'legacySignout';
@@ -270,6 +271,11 @@ export function mergeConfigDefaults(): Config {
   cfg.rss = {
     url: cfg.rss?.url || '',
     enabled: cfg.rss?.enabled === true,
+  };
+
+  // Physicians calendar
+  cfg.physicians = {
+    calendarUrl: cfg.physicians?.calendarUrl || '',
   };
 
   // Privacy (default true)

--- a/src/ui/physicians.ts
+++ b/src/ui/physicians.ts
@@ -1,4 +1,6 @@
-const CAL_URL = 'https://www.bytebloc.com/sk/?76b6a156';
+import { getConfig } from '@/state';
+
+const DEFAULT_CAL_URL = 'https://www.bytebloc.com/sk/?76b6a156';
 
 type Event = {
   date: string;
@@ -47,7 +49,9 @@ function parseICS(text: string): Event[] {
 /** Fetch and render physicians for the given day. */
 export async function renderPhysicians(el: HTMLElement, dateISO: string): Promise<void> {
   try {
-    const res = await fetch(CAL_URL);
+    const cfg = getConfig();
+    const url = cfg.physicians?.calendarUrl || DEFAULT_CAL_URL;
+    const res = await fetch(url);
     if (!res.ok) throw new Error('failed');
     const ics = await res.text();
     const events = parseICS(ics);

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -242,6 +242,7 @@ function renderGeneralSettings() {
       <div class="form-row"><label><input type="checkbox" id="gs-privacy"${cfg.privacy!==false?' checked':''}> Privacy mode: First LastInitial</label></div>
       <div class="form-row"><label>RSS URL <input id="gs-rss" value="${cfg.rss?.url || ''}"></label></div>
       <div class="form-row"><label><input type="checkbox" id="gs-rss-en"${cfg.rss?.enabled?' checked':''}> Enable feed</label></div>
+      <div class="form-row"><label>Physicians calendar URL <input id="gs-phys-url" value="${cfg.physicians?.calendarUrl || ''}"></label></div>
       <div class="form-row">
         <label>Signout Button Mode</label>
         <div>
@@ -337,6 +338,10 @@ function renderGeneralSettings() {
   (document.getElementById('gs-rss-en') as HTMLInputElement).addEventListener('change', async (e) => {
     cfg.rss!.enabled = (e.target as HTMLInputElement).checked;
     await saveConfig({ rss: cfg.rss });
+  });
+  (document.getElementById('gs-phys-url') as HTMLInputElement).addEventListener('input', async (e) => {
+    cfg.physicians!.calendarUrl = (e.target as HTMLInputElement).value;
+    await saveConfig({ physicians: cfg.physicians });
   });
 
   el.querySelectorAll('input[name="signout-mode"]').forEach((r) => {

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -23,6 +23,7 @@ describe('config round trip', () => {
       dtoMinutes: 50,
       showPinned: { charge: false, triage: true },
       rss: { url: 'http://x', enabled: true },
+      physicians: { calendarUrl: 'http://phys' },
       privacy: false,
       ui: { signoutMode: 'legacySignout', rightSidebarWidthPx: 350 },
     });
@@ -31,6 +32,7 @@ describe('config round trip', () => {
     expect(cfg.dtoMinutes).toBe(50);
     expect(cfg.showPinned?.charge).toBe(false);
     expect(cfg.rss?.url).toBe('http://x');
+    expect(cfg.physicians?.calendarUrl).toBe('http://phys');
     expect(cfg.privacy).toBe(false);
     expect(cfg.ui?.signoutMode).toBe('legacySignout');
     expect(cfg.ui?.rightSidebarWidthPx).toBe(350);


### PR DESCRIPTION
## Summary
- allow configuring physician calendar URL through state config
- expose calendar URL input in General settings
- pull physician schedule from configured URL with fallback to default

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1e5a081bc8327acdcce11234c13e1