### PR TITLE
Ensure roster array before saving

### DIFF
--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -64,8 +64,8 @@ export function renderHeader() {
 
       tasks.push(Server.save('config', getConfig()));
 
-      const roster = await DB.get(KS.STAFF);
-      if (roster) tasks.push(Server.save('roster', roster));
+      const roster = (await DB.get(KS.STAFF)) ?? [];
+      if (Array.isArray(roster)) tasks.push(Server.save('roster', roster));
 
       await Promise.all(tasks);
       showBanner('Published');


### PR DESCRIPTION
## Summary
- Ensure roster defaults to an empty array and verify it's an array before saving

## Testing
- `npm test` *(fails: connect ECONNREFUSED ::1:3000; ReferenceError: window is not defined; Test timed out)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1e7b98cb0832786ff18229d305176