### PR TITLE
Check roster type before publishing

### DIFF
--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -1,5 +1,5 @@
 import { STATE, getConfig, DB, KS, getActiveBoardCache } from '@/state';
-import type { ActiveBoard } from '@/state';
+import type { ActiveBoard, Staff } from '@/state';
 import { getThemeConfig, saveThemeConfig, applyTheme } from '@/state/theme';
 import { deriveShift, fmtLong } from '@/utils/time';
 import { manualHandoff, renderAll } from '@/main';
@@ -64,8 +64,10 @@ export function renderHeader() {
 
       tasks.push(Server.save('config', getConfig()));
 
-      const roster = await DB.get(KS.STAFF);
-      if (roster) tasks.push(Server.save('roster', roster));
+      const roster = await DB.get<Staff[]>(KS.STAFF);
+      if (Array.isArray(roster) && roster.length) {
+        tasks.push(Server.save('roster', roster));
+      }
 
       await Promise.all(tasks);
       showBanner('Published');


### PR DESCRIPTION
## Summary
- guard roster save with array check

## Testing
- `npm run precheck`
- `npm test` *(fails: connect ENETUNREACH, Test timed out, ReferenceError: window is not defined)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1e747b5b483278468a6f9291d9da5