### PR TITLE
fix server alias and config typing

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,21 @@
+/**
+ * Wrapper around the globally provided `Server` adapter.
+ * Exports helper functions so modules can `import * as Server from '@/server'`.
+ */
+
+// `Server` is declared globally in src/types/server.d.ts
+const api: ServerAPI | undefined = (globalThis as any).Server;
+
+function ensure(): ServerAPI {
+  if (!api) throw new Error('Server adapter not available');
+  return api;
+}
+
+export const load: ServerAPI['load'] = (...args) => ensure().load(...(args as any));
+export const save: ServerAPI['save'] = (...args) => ensure().save(...(args as any));
+export const softDeleteStaff: ServerAPI['softDeleteStaff'] = (...args) =>
+  ensure().softDeleteStaff(...(args as any));
+export const exportHistoryCSV: ServerAPI['exportHistoryCSV'] = (...args) =>
+  ensure().exportHistoryCSV(...(args as any));
+
+export default { load, save, softDeleteStaff, exportHistoryCSV };

--- a/src/state/config.ts
+++ b/src/state/config.ts
@@ -36,6 +36,7 @@ export type Config = {
   dtoMinutes?: number;
   showPinned?: { charge: boolean; triage: boolean };
   rss?: { url: string; enabled: boolean };
+  physicians?: { calendarUrl: string };
   privacy?: boolean;
   ui?: {
     signoutMode?: 'shiftHuddle' | 'disabled' | 'legacySignout';
@@ -68,6 +69,7 @@ let CONFIG_CACHE: Config = {
   dtoMinutes: 60,
   showPinned: { charge: true, triage: true },
   rss: { url: '', enabled: false },
+  physicians: { calendarUrl: '' },
   privacy: true,
   ui: {
     signoutMode: 'shiftHuddle',
@@ -186,6 +188,11 @@ export function mergeConfigDefaults(): Config {
   cfg.rss = {
     url: cfg.rss?.url || '',
     enabled: cfg.rss?.enabled === true,
+  };
+
+  // Physicians calendar
+  cfg.physicians = {
+    calendarUrl: cfg.physicians?.calendarUrl || '',
   };
 
   // Privacy (default true)

--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -1,8 +1,3 @@
-Here’s the cleaned, unified `renderHeader` module with the consolidated `@/state` imports and the missing `Server` import wired up.
-
-```ts
-// header.ts — merged & de-conflicted
-
 import * as Server from '@/server';
 import {
   STATE,
@@ -124,5 +119,3 @@ export function renderHeader() {
     location.reload();
   });
 }
-```
-


### PR DESCRIPTION
## Summary
- add client-side Server adapter so @/server resolves
- include physicians calendar URL in Config with defaults
- clean header module to rely on server shim

## Testing
- `npm test` *(fails: Test timed out; window is not defined; expected button null)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1ee83eaf88327ab15d82650897323