### PR TITLE
Ensure server API signatures match TypeScript definitions

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,29 @@
+import type { ServerAPI } from '@/types/server';
+
+let api: ServerAPI | undefined;
+
+/** Ensure the global Server adapter is available. */
+function ensure(): ServerAPI {
+  if (!api) {
+    api = (window as any).Server as ServerAPI;
+  }
+  return api;
+}
+
+/** Proxy to {@link ServerAPI.load}. */
+export const load: ServerAPI['load'] = (key, params?) => ensure().load(key, params);
+
+/** Proxy to {@link ServerAPI.save}. */
+export const save: ServerAPI['save'] = (key, payload, params?) =>
+  ensure().save(key, payload, params);
+
+/** Proxy to {@link ServerAPI.softDeleteStaff}. */
+export const softDeleteStaff: ServerAPI['softDeleteStaff'] = (id) =>
+  ensure().softDeleteStaff(id);
+
+/** Proxy to {@link ServerAPI.exportHistoryCSV}. */
+export const exportHistoryCSV: ServerAPI['exportHistoryCSV'] = (filters?) =>
+  ensure().exportHistoryCSV(filters);
+
+export default { load, save, softDeleteStaff, exportHistoryCSV };
+

--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -107,7 +107,7 @@ export function renderHeader() {
         } catch {}
       }
 
-      const board = await Server.load<ActiveBoard>('active', { date: dateISO, shift });
+      const board = await Server.load('active', { date: dateISO, shift });
       if (board) await DB.set(KS.ACTIVE(dateISO, shift), board);
 
       await renderAll();


### PR DESCRIPTION
## Summary
- Add a `src/server.ts` adapter that proxies to the global Server object with typed functions
- Remove unsupported generic from `Server.load` in header

## Testing
- `npm test` *(fails: tests timed out when hitting network/db)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1eff3d98883279178e5d2c09a4478