### PR TITLE
fix: allow pct zone drag and preview theme

### DIFF
--- a/src/ui/builder.ts
+++ b/src/ui/builder.ts
@@ -301,6 +301,7 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
           const fromIdx = Number(zoneIdxStr);
           if (!isNaN(fromIdx) && fromIdx !== i) {
             const [moved] = cfg.zones.splice(fromIdx, 1);
+            moved.pct = z.pct;
             cfg.zones.splice(i, 0, moved);
             board.zones = Object.fromEntries(
               cfg.zones.map((zz) => [zz.name, board.zones[zz.name] || []])

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -438,7 +438,20 @@ function renderDisplaySettings() {
     const saveBtn = document.getElementById('ds-save') as HTMLButtonElement;
     saveBtn.disabled = lr < 4.5 || dr < 4.5;
   };
-  el.querySelectorAll('input[name="ds-light"],input[name="ds-dark"]').forEach((i) => i.addEventListener('change', updateContrast));
+  el
+    .querySelectorAll('input[name="ds-light"],input[name="ds-dark"]')
+    .forEach((i) =>
+      i.addEventListener('change', () => {
+        updateContrast();
+        const lightId = (
+          document.querySelector('input[name="ds-light"]:checked') as HTMLInputElement
+        ).value;
+        const darkId = (
+          document.querySelector('input[name="ds-dark"]:checked') as HTMLInputElement
+        ).value;
+        applyTheme({ ...cfg, lightPreset: lightId, darkPreset: darkId });
+      })
+    );
   updateContrast();
 
   document.getElementById('ds-save')!.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- allow dragging zones between regular and patient care team areas
- preview display theme when selecting preset options

## Testing
- `npm test` *(fails: tests/signoutDom.spec.ts > signout button modes > omits button when mode=disabled)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1f404339083278fae871dbd8b1bb2