### PR TITLE
fix: keep board header fixed

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -82,7 +82,7 @@
 html,body{height:100%;overflow:auto}
 body{margin:0;background:var(--bg);color:var(--text-high);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
 .wrap{width:100%;padding:var(--gap)}
-header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-items:center;margin-bottom:var(--gap);position:sticky;top:0;z-index:var(--z-sticky)}
+header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-items:center;margin-bottom:var(--gap);position:sticky;top:0;z-index:var(--z-sticky);background:var(--bg)}
 .title{font-size:var(--f-xl);font-weight:800;letter-spacing:.2px}
 .subtitle{color:var(--text-muted);font-size:var(--f)}
 .time-block{text-align:right}
@@ -94,7 +94,6 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .layout{display:grid;grid-template-columns:1fr var(--right-sidebar-w);gap:var(--gap)}
 .layout[data-testid="main-board"]{
   min-height:100vh;
-  overflow:auto;
   background:var(--panel);
 }
 .layout[data-testid="main-board"] .col{
@@ -106,7 +105,7 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .panel{background:var(--panel);color:var(--text-high);border:1px solid var(--line);border-radius:var(--radius);padding:12px 14px;box-shadow:var(--elev-1);display:flex;flex-direction:column;min-height:0}
 .panel h3{color:var(--text-high);font-size:clamp(14px,.95vw,16px)}
 .panel .muted{color:var(--text-muted)}
-.col{display:flex;flex-direction:column;gap:var(--gap);height:100%;min-height:0;overflow:hidden}
+.col{display:flex;flex-direction:column;gap:var(--gap)}
 /* merged resolution */
 .col>.panel{flex:0 0 auto}
 #incoming-panel,#offgoing-panel{flex:1}


### PR DESCRIPTION
## Summary
- keep board header visible by removing internal scroll and applying background

## Testing
- `npm test` *(fails: signout button modes > omits button when mode=disabled)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1f479f39c8327a64836d1582b6909