### PR TITLE
feat(server): add PDO SQLite storage

### DIFF
--- a/server/api.php
+++ b/server/api.php
@@ -2,9 +2,8 @@
 declare(strict_types=1);
 
 /**
- * StaffBoard API (cPanel-safe, file-backed JSON store)
- * - Data directory: /data (auto-created)
- * - Keys: roster.json, config.json, active.json, history.json
+ * StaffBoard API (DB-backed JSON store)
+ * - Database: SQLite file specified by `HEYBRE_DB_PATH` (defaults to server/data.sqlite)
  * - Auth: send `X-API-Key` header matching `HEYBRE_API_KEY`
  * - Endpoints:
  *   ?action=load&key=roster|config|active[&date=YYYY-MM-DD&shift=day|night]
@@ -24,6 +23,8 @@ $ROOT_DIR = __DIR__;
 $DATA_DIR = $ROOT_DIR . '/data';
 if (!is_dir($DATA_DIR)) { @mkdir($DATA_DIR, 0775, true); }
 
+require __DIR__ . '/db.php';
+
 /* ---------- helpers ---------- */
 function bad(string $msg, int $code = 400): void {
   http_response_code($code);
@@ -40,43 +41,21 @@ function normalizeKey(string $key): string {
   if (!in_array($key, $allowed, true)) bad('invalid key');
   return $key;
 }
-function safeReadJson(string $path, $default) {
-  if (!file_exists($path)) return $default;
-  $raw = @file_get_contents($path);
-  if ($raw === false) return $default;
-  $data = json_decode($raw, true);
-  return (json_last_error() === JSON_ERROR_NONE && $data !== null) ? $data : $default;
-}
-function safeWriteJson(string $path, $data): void {
-  $dir = dirname($path);
-  if (!is_dir($dir)) @mkdir($dir, 0775, true);
-  $tmp = $path . '.tmp';
-  $fp = @fopen($tmp, 'w');
-  if (!$fp) throw new RuntimeException('write open failed');
-  $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
-  if ($json === false) { @fclose($fp); @unlink($tmp); throw new RuntimeException('encode failed'); }
-  if (@fwrite($fp, $json) === false) { @fclose($fp); @unlink($tmp); throw new RuntimeException('write failed'); }
-  @fclose($fp);
-  if (!@rename($tmp, $path)) { @unlink($path); if (!@rename($tmp, $path)) throw new RuntimeException('rename failed'); }
-}
+
 /** seed roster on first run from staff-roster-full.json */
-function ensureRosterExists(string $dataDir, string $rootDir): void {
-  $rosterPath = $dataDir . '/roster.json';
-  if (file_exists($rosterPath)) return;
+function ensureRosterExists(string $rootDir): void {
+  $existing = kvGet('roster', null);
+  if ($existing !== null) return;
   $seed = $rootDir . '/staff-roster-full.json';
   $default = [];
   if (file_exists($seed)) {
-    $seedData = safeReadJson($seed, []);
-    foreach ($seedData as &$r) if (!isset($r['active'])) $r['active'] = true;
-    $default = $seedData;
+    $seedData = json_decode(@file_get_contents($seed) ?: '[]', true);
+    if (is_array($seedData)) {
+      foreach ($seedData as &$r) if (!isset($r['active'])) $r['active'] = true;
+      $default = $seedData;
+    }
   }
-  safeWriteJson($rosterPath, $default);
-}
-/** build path for per-shift active snapshots; fallback to active.json */
-function activePath(string $dataDir, ?string $date, ?string $shift): string {
-  $dateOk  = $date && preg_match('/^\d{4}-\d{2}-\d{2}$/', $date);
-  $shiftOk = $shift === 'day' || $shift === 'night';
-  return ($dateOk && $shiftOk) ? "$dataDir/active-$date-$shift.json" : "$dataDir/active.json";
+  kvSet('roster', $default);
 }
 
 $API_KEY = getenv('HEYBRE_API_KEY') ?: '';
@@ -88,11 +67,10 @@ if ($API_KEY === '' || $REQ_KEY !== $API_KEY) {
 /* ---------- router ---------- */
 $action = $_GET['action'] ?? '';
 $key    = $_GET['key'] ?? '';
-$historyPath = $DATA_DIR . '/history.json';
 $physiciansUrl = 'https://www.bytebloc.com/sk/?76b6a156';
 
 try {
-  ensureRosterExists($DATA_DIR, $ROOT_DIR);
+  ensureRosterExists($ROOT_DIR);
 
   switch ($action) {
     case 'ping':
@@ -105,17 +83,16 @@ try {
       if ($key === 'active') {
         $date  = $_GET['date']  ?? null;
         $shift = $_GET['shift'] ?? null;
-        $path  = activePath($DATA_DIR, $date, $shift);
+        $data  = activeLoad($date, $shift);
       } else {
-        $path = "$DATA_DIR/$key.json";
+        $defaults = [
+          'roster' => [],
+          'config' => new stdClass(),
+        ];
+        $data = kvGet($key, $defaults[$key] ?? new stdClass());
       }
 
-      $defaults = [
-        'roster' => [],
-        'config' => new stdClass(),
-        'active' => new stdClass(),
-      ];
-      ok(safeReadJson($path, $defaults[$key] ?? new stdClass()));
+      ok($data);
     }
 
     case 'save': {
@@ -133,29 +110,21 @@ try {
       if ($key === 'active') {
         $date  = (is_array($data) ? ($data['dateISO'] ?? null) : null) ?? ($_GET['date']  ?? null);
         $shift = (is_array($data) ? ($data['shift']   ?? null) : null) ?? ($_GET['shift'] ?? null);
-        $snapPath = activePath($DATA_DIR, $date, $shift);
-        safeWriteJson($snapPath, $data);
-        // also keep latest pointer for clients that don't pass date/shift
-        safeWriteJson("$DATA_DIR/active.json", $data);
+        activeSave($data, $date, $shift);
+        if (($_GET['appendHistory'] ?? '') === 'true') {
+          if (is_array($data)) $data['publishedAt'] = gmdate('c');
+          historyInsert($data);
+        }
       } else {
-        safeWriteJson("$DATA_DIR/$key.json", $data);
+        kvSet($key, $data);
       }
 
-      if ($key === 'active' && (($_GET['appendHistory'] ?? '') === 'true')) {
-        $hist = safeReadJson($historyPath, []);
-        if (!is_array($hist)) $hist = [];
-        if (is_array($data))  $data['publishedAt'] = gmdate('c');
-        $hist[] = $data;
-        safeWriteJson($historyPath, $hist);
-      }
-
-      ok(['ok'=>true]);
+      ok(['ok' => true]);
     }
 
     case 'history': {
       $mode = $_GET['mode'] ?? '';
-      $hist = safeReadJson($historyPath, []);
-      if (!is_array($hist)) $hist = [];
+      $hist = historyAll();
 
       if ($mode === 'list') {
         $date = $_GET['date'] ?? '';
@@ -183,16 +152,15 @@ try {
     case 'softDeleteStaff': {
       $id = $_GET['id'] ?? '';
       if ($id === '') bad('missing id');
-      $rosterPath = "$DATA_DIR/roster.json";
-      $roster = safeReadJson($rosterPath, []);
+      $roster = kvGet('roster', []);
       if (!is_array($roster)) $roster = [];
       $found = false;
       foreach ($roster as &$s) {
         if (($s['id'] ?? '') === $id) { $s['active'] = false; $found = true; break; }
       }
       if (!$found) bad('not found', 404);
-      safeWriteJson($rosterPath, $roster);
-      ok(['ok'=>true]);
+      kvSet('roster', $roster);
+      ok(['ok' => true]);
     }
 
     case 'exportHistoryCSV': {
@@ -203,8 +171,7 @@ try {
       $to    = $_GET['to'] ?? '';
       $nurse = $_GET['nurseId'] ?? '';
 
-      $hist = safeReadJson($historyPath, []);
-      if (!is_array($hist)) $hist = [];
+      $hist = historyAll();
 
       $out = fopen('php://output', 'w');
       fputcsv($out, ['date','shift','zone','id','name','type']);

--- a/server/db.php
+++ b/server/db.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Simple PDO-based storage for StaffBoard.
+ */
+
+function db(): PDO {
+  static $pdo = null;
+  if ($pdo === null) {
+    $path = getenv('HEYBRE_DB_PATH');
+    if ($path === false || $path === '') {
+      $path = __DIR__ . '/data.sqlite';
+    }
+    $pdo = new PDO('sqlite:' . $path);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    initDb($pdo);
+  }
+  return $pdo;
+}
+
+function initDb(PDO $pdo): void {
+  $pdo->exec('CREATE TABLE IF NOT EXISTS kv_store (key TEXT PRIMARY KEY, value TEXT NOT NULL)');
+  $pdo->exec('CREATE TABLE IF NOT EXISTS active_snapshots (date TEXT NOT NULL, shift TEXT NOT NULL, data TEXT NOT NULL, PRIMARY KEY(date, shift))');
+  $pdo->exec('CREATE TABLE IF NOT EXISTS history (id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT NOT NULL)');
+}
+
+function kvGet(string $key, $default) {
+  $stmt = db()->prepare('SELECT value FROM kv_store WHERE key = :key');
+  $stmt->execute([':key' => $key]);
+  $raw = $stmt->fetchColumn();
+  if ($raw === false) return $default;
+  $data = json_decode($raw, true);
+  return (json_last_error() === JSON_ERROR_NONE) ? $data : $default;
+}
+
+function kvSet(string $key, $data): void {
+  $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+  db()->prepare('REPLACE INTO kv_store (key, value) VALUES (:k, :v)')->execute([':k' => $key, ':v' => $json]);
+}
+
+function activeSave($data, ?string $date, ?string $shift): void {
+  $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+  if ($date && $shift) {
+    db()->prepare('REPLACE INTO active_snapshots (date, shift, data) VALUES (:d, :s, :j)')->execute([
+      ':d' => $date,
+      ':s' => $shift,
+      ':j' => $json,
+    ]);
+  }
+  db()->prepare('REPLACE INTO kv_store (key, value) VALUES ("active", :j)')->execute([':j' => $json]);
+}
+
+function activeLoad(?string $date, ?string $shift) {
+  if ($date && $shift) {
+    $stmt = db()->prepare('SELECT data FROM active_snapshots WHERE date = :d AND shift = :s');
+    $stmt->execute([':d' => $date, ':s' => $shift]);
+    $raw = $stmt->fetchColumn();
+    if ($raw !== false) {
+      $out = json_decode($raw, true);
+      if (json_last_error() === JSON_ERROR_NONE) return $out;
+    }
+  }
+  return kvGet('active', new stdClass());
+}
+
+function historyInsert($data): void {
+  $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+  db()->prepare('INSERT INTO history (data) VALUES (:j)')->execute([':j' => $json]);
+}
+
+function historyAll(): array {
+  $stmt = db()->query('SELECT data FROM history ORDER BY id ASC');
+  $rows = $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
+  $out = [];
+  foreach ($rows as $raw) {
+    $d = json_decode($raw, true);
+    if (json_last_error() === JSON_ERROR_NONE) $out[] = $d;
+  }
+  return $out;
+}
+
+?>

--- a/server/migrate.php
+++ b/server/migrate.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/db.php';
+
+$DATA_DIR = __DIR__ . '/data';
+
+// ensure database exists
+initDb(db());
+
+// migrate simple keys
+foreach (['roster', 'config', 'active'] as $key) {
+  $path = "$DATA_DIR/$key.json";
+  if (is_file($path)) {
+    $data = json_decode(file_get_contents($path) ?: '', true);
+    if ($data !== null) {
+      kvSet($key, $data);
+    }
+  }
+}
+
+// migrate active snapshots
+foreach (glob($DATA_DIR . '/active-*-*.json') as $file) {
+  if (preg_match('/active-(\d{4}-\d{2}-\d{2})-(day|night)\.json$/', $file, $m)) {
+    $data = json_decode(file_get_contents($file) ?: '', true);
+    if ($data !== null) {
+      activeSave($data, $m[1], $m[2]);
+    }
+  }
+}
+
+// migrate history
+$histPath = $DATA_DIR . '/history.json';
+if (is_file($histPath)) {
+  $hist = json_decode(file_get_contents($histPath) ?: '', true);
+  if (is_array($hist)) {
+    foreach ($hist as $entry) {
+      historyInsert($entry);
+    }
+  }
+}
+
+echo "Migration complete\n";

--- a/server/migrations/001_init.sql
+++ b/server/migrations/001_init.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS kv_store (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS active_snapshots (
+  date  TEXT NOT NULL,
+  shift TEXT NOT NULL,
+  data  TEXT NOT NULL,
+  PRIMARY KEY (date, shift)
+);
+
+CREATE TABLE IF NOT EXISTS history (
+  id   INTEGER PRIMARY KEY AUTOINCREMENT,
+  data TEXT NOT NULL
+);

--- a/tests/api-db.spec.ts
+++ b/tests/api-db.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+let server: ChildProcess;
+const dbPath = resolve('server/test.sqlite');
+
+beforeAll(async () => {
+  try { rmSync(dbPath); } catch {}
+  server = spawn('php', ['-S', '127.0.0.1:8021', '-t', 'server'], {
+    env: { ...process.env, HEYBRE_API_KEY: 'test-key', HEYBRE_DB_PATH: dbPath },
+    stdio: 'ignore',
+  });
+  await new Promise((resolve) => setTimeout(resolve, 500));
+});
+
+afterAll(() => {
+  server.kill();
+  try { rmSync(dbPath); } catch {}
+});
+
+describe('DB-backed API', () => {
+  it('saves and loads config using SQLite', async () => {
+    await fetch('http://127.0.0.1:8021/api.php?action=save&key=config', {
+      method: 'POST',
+      headers: { 'X-API-Key': 'test-key' },
+      body: JSON.stringify({ foo: 'bar' }),
+    });
+    const res = await fetch('http://127.0.0.1:8021/api.php?action=load&key=config', {
+      headers: { 'X-API-Key': 'test-key' },
+    });
+    const json = await res.json();
+    expect(json).toEqual({ foo: 'bar' });
+  });
+
+  it('stores history entries when saving active', async () => {
+    const payload = { dateISO: '2024-01-02', shift: 'day', assignments: [] };
+    await fetch('http://127.0.0.1:8021/api.php?action=save&key=active&appendHistory=true', {
+      method: 'POST',
+      headers: { 'X-API-Key': 'test-key', 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const res = await fetch('http://127.0.0.1:8021/api.php?action=history&mode=list&date=2024-01-02', {
+      headers: { 'X-API-Key': 'test-key' },
+    });
+    const list = await res.json();
+    expect(list.length).toBe(1);
+    expect(list[0].dateISO).toBe('2024-01-02');
+  });
+});


### PR DESCRIPTION
## Summary
- add PDO-powered SQLite layer for server data
- swap file-based reads/writes for database queries
- include migration script and test coverage for DB-backed API

## Testing
- `npm test` *(fails: tests/signoutDom.spec.ts > signout button modes > omits button when mode=disabled)*


------
https://chatgpt.com/codex/tasks/task_e_68b1f5d8410c8327ae168f9ba07396ab