### PR TITLE
Fix theme preset defaults and add preset validation

### DIFF
--- a/src/state/config.ts
+++ b/src/state/config.ts
@@ -2,6 +2,7 @@ import * as DB from '@/db';
 import { DEFAULT_WEATHER_COORDS } from '@/config/weather';
 import { normalizeZones, type ZoneDef } from '@/utils/zones';
 import type { UIThemeConfig } from '@/state/theme';
+import { THEME_PRESETS } from '@/state/theme';
 import * as Server from '@/server';
 import { KS } from './keys';
 import { STATE } from './board';
@@ -81,8 +82,8 @@ let CONFIG_CACHE: Config = {
   uiTheme: {
     mode: 'system',
     scale: 1,
-    lightPreset: 'fog',
-    darkPreset: 'midnight',
+    lightPreset: 'light-soft-gray',
+    darkPreset: 'dark-charcoal-navy',
     highContrast: false,
     compact: false,
   },
@@ -211,11 +212,17 @@ export function mergeConfigDefaults(): Config {
   };
 
   // Theme defaults
+  const lightDefault = 'light-soft-gray';
+  const darkDefault = 'dark-charcoal-navy';
+  const light = cfg.uiTheme?.lightPreset;
+  const dark = cfg.uiTheme?.darkPreset;
+  const validLight = THEME_PRESETS.some((p) => p.id === light && p.mode === 'light');
+  const validDark = THEME_PRESETS.some((p) => p.id === dark && p.mode === 'dark');
   cfg.uiTheme = {
     mode: cfg.uiTheme?.mode || 'system',
     scale: cfg.uiTheme?.scale ?? 1,
-    lightPreset: cfg.uiTheme?.lightPreset || 'fog',
-    darkPreset: cfg.uiTheme?.darkPreset || 'midnight',
+    lightPreset: validLight ? (light as string) : lightDefault,
+    darkPreset: validDark ? (dark as string) : darkDefault,
     highContrast: cfg.uiTheme?.highContrast === true,
     compact: cfg.uiTheme?.compact === true,
   };

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -21,6 +21,7 @@ import {
   type Assignment,
 } from '@/state/history';
 import type { UIThemeConfig } from '@/state/theme';
+import { THEME_PRESETS } from '@/state/theme';
 
 export type WidgetsConfig = {
   show?: boolean;
@@ -175,8 +176,8 @@ let CONFIG_CACHE: Config = {
   uiTheme: {
     mode: 'system',
     scale: 1,
-    lightPreset: 'fog',
-    darkPreset: 'midnight',
+    lightPreset: 'light-soft-gray',
+    darkPreset: 'dark-charcoal-navy',
     highContrast: false,
     compact: false,
   },
@@ -305,11 +306,17 @@ export function mergeConfigDefaults(): Config {
   };
 
   // Theme defaults
+  const lightDefault = 'light-soft-gray';
+  const darkDefault = 'dark-charcoal-navy';
+  const light = cfg.uiTheme?.lightPreset;
+  const dark = cfg.uiTheme?.darkPreset;
+  const validLight = THEME_PRESETS.some((p) => p.id === light && p.mode === 'light');
+  const validDark = THEME_PRESETS.some((p) => p.id === dark && p.mode === 'dark');
   cfg.uiTheme = {
     mode: cfg.uiTheme?.mode || 'system',
     scale: cfg.uiTheme?.scale ?? 1,
-    lightPreset: cfg.uiTheme?.lightPreset || 'fog',
-    darkPreset: cfg.uiTheme?.darkPreset || 'midnight',
+    lightPreset: validLight ? (light as string) : lightDefault,
+    darkPreset: validDark ? (dark as string) : darkDefault,
     highContrast: cfg.uiTheme?.highContrast === true,
     compact: cfg.uiTheme?.compact === true,
   };

--- a/tests/themeConfig.spec.ts
+++ b/tests/themeConfig.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+/** @vitest-environment happy-dom */
+
+vi.mock('@/db', () => {
+  const store: Record<string, any> = {};
+  return {
+    get: async (k: string) => store[k],
+    set: async (k: string, v: any) => {
+      store[k] = v;
+    },
+    del: async (k: string) => {
+      delete store[k];
+    },
+    keys: async () => Object.keys(store),
+  };
+});
+
+import { saveConfig } from '@/state/config';
+import { getThemeConfig } from '@/state/theme';
+
+describe('theme config presets', () => {
+  it('falls back to defaults for unknown preset ids', async () => {
+    await saveConfig({ uiTheme: { lightPreset: 'fog', darkPreset: 'midnight' } as any });
+    const cfg = getThemeConfig();
+    expect(cfg.lightPreset).toBe('light-soft-gray');
+    expect(cfg.darkPreset).toBe('dark-charcoal-navy');
+  });
+});


### PR DESCRIPTION
## Summary
- default UI theme presets now reference existing themes
- validate configured theme presets against available list and fall back to defaults
- add unit test ensuring unknown preset ids reset to defaults

## Testing
- `npm test` *(fails: tests/signoutDom.spec.ts > signout button modes > omits button when mode=disabled)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1faff58308327a1cd9b0477e01fda