### PR TITLE
Track nurse reassignment history and improve history UI

### DIFF
--- a/src/history/NurseHistory.ts
+++ b/src/history/NurseHistory.ts
@@ -17,8 +17,8 @@ export function renderNurseHistory(root: HTMLElement): void {
         <button id="hist-nurse-export" class="btn">Export CSV</button>
       </div>
       <table class="history-table">
-        <thead><tr><th>Date</th><th>Shift</th><th>Zone</th></tr></thead>
-        <tbody id="hist-nurse-body"></tbody>
+        <thead><tr><th>Date</th><th>Shift</th><th>Zone</th><th>Prev Zone</th></tr></thead>
+        <tbody id="hist-nurse-body"><tr><td colspan="4">Select a nurse</td></tr></tbody>
       </table>
     </div>
   `;
@@ -40,12 +40,14 @@ export function renderNurseHistory(root: HTMLElement): void {
   document.getElementById('hist-nurse-load')!.addEventListener('click', async () => {
     const id = sel.value;
     current = await findShiftsByStaff(id);
-    body.innerHTML = current
-      .map(
-        (r) =>
-          `<tr><td>${r.dateISO}</td><td>${r.shift}</td><td>${r.zone}</td></tr>`
-      )
-      .join('');
+    body.innerHTML = current.length
+      ? current
+          .map(
+            (r) =>
+              `<tr><td>${r.dateISO}</td><td>${r.shift}</td><td>${r.zone}</td><td>${r.previousZone ?? ''}</td></tr>`
+          )
+          .join('')
+      : '<tr><td colspan="4">No history found</td></tr>';
   });
 
   document

--- a/src/history/history.css
+++ b/src/history/history.css
@@ -1,2 +1,5 @@
 .history-nav{display:flex;gap:8px;margin-bottom:12px}
 .history-nav button{padding:4px 8px}
+.history-table{border-collapse:collapse;width:100%}
+.history-table th,.history-table td{border:1px solid #ccc;padding:4px;text-align:left}
+.history-table thead{background:#f5f5f5}

--- a/src/history/index.ts
+++ b/src/history/index.ts
@@ -71,7 +71,7 @@ export function exportShiftCSV(snapshot: PublishedShiftSnapshot): string {
  * @returns CSV string
  */
 export function exportNurseHistoryCSV(entries: NurseShiftIndexEntry[]): string {
-  const header = 'staffId,displayName,role,date,shift,zone,startISO,endISO,dto';
+  const header = 'staffId,displayName,role,date,shift,zone,previousZone,startISO,endISO,dto';
   const rows = entries
     .map((e) =>
       [
@@ -81,6 +81,7 @@ export function exportNurseHistoryCSV(entries: NurseShiftIndexEntry[]): string {
         e.dateISO,
         e.shift,
         e.zone,
+        e.previousZone ?? '',
         e.startISO,
         e.endISO,
         e.dto ? '1' : '0',

--- a/src/state/history.ts
+++ b/src/state/history.ts
@@ -95,6 +95,7 @@ export interface NurseShiftIndexEntry {
   dateISO: string;
   shift: ShiftKind;
   zone: string;
+  previousZone?: string;
   startISO: string;
   endISO: string;
   dto?: boolean;
@@ -144,6 +145,9 @@ export async function indexStaffAssignments(
   for (const a of snapshot.zoneAssignments) {
     const key = STAFF_KEY(a.staffId);
     const list = (await kvGet<NurseShiftIndexEntry[]>(key)) || [];
+    const prev = list.find(
+      (e) => e.dateISO === snapshot.dateISO && e.shift === snapshot.shift
+    );
     const entry: NurseShiftIndexEntry = {
       staffId: a.staffId,
       displayName: a.displayName,
@@ -151,6 +155,7 @@ export async function indexStaffAssignments(
       dateISO: snapshot.dateISO,
       shift: snapshot.shift,
       zone: a.zone,
+      previousZone: prev?.zone,
       startISO: a.startISO,
       endISO: a.endISO,
       dto: !!a.dto,

--- a/tests/history.spec.ts
+++ b/tests/history.spec.ts
@@ -72,6 +72,41 @@ describe('history persistence', () => {
     expect(rows[0].dto).toBe(true);
   });
 
+  it('records previous zone when nurse moves', async () => {
+    const first: PublishedShiftSnapshot = {
+      ...base,
+      zoneAssignments: [
+        {
+          staffId: '1',
+          displayName: 'Alice',
+          role: 'nurse',
+          zone: 'A',
+          startISO: '2024-01-01T07:00:00.000Z',
+          endISO: '2024-01-01T10:00:00.000Z',
+        },
+      ],
+    };
+    const second: PublishedShiftSnapshot = {
+      ...base,
+      zoneAssignments: [
+        {
+          staffId: '1',
+          displayName: 'Alice',
+          role: 'nurse',
+          zone: 'B',
+          startISO: '2024-01-01T10:00:00.000Z',
+          endISO: '2024-01-01T19:00:00.000Z',
+        },
+      ],
+    };
+    await indexStaffAssignments(first);
+    await indexStaffAssignments(second);
+    const rows = await findShiftsByStaff('1');
+    expect(rows.length).toBe(2);
+    expect(rows[0].zone).toBe('B');
+    expect(rows[0].previousZone).toBe('A');
+  });
+
   it('saves and fetches huddles', async () => {
     const rec: HuddleRecord = {
       dateISO: '2024-01-01',


### PR DESCRIPTION
## Summary
- index staff assignments with `previousZone` to track last location
- enhance nurse history UI and CSV export to show previous zone
- style history tables for better readability
- add test covering nurse movement history

## Testing
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:8021)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2ae04955c8327a5e9142fa8d63b0e