### PR TITLE
Fix drag-and-drop for patient care team zones

### DIFF
--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -287,6 +287,25 @@ function renderZones(
       ev.dataTransfer?.setData('zone-index', String(i));
     });
 
+    section.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+
+    section.addEventListener('drop', async (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const zoneIdxStr = (e as DragEvent).dataTransfer?.getData('zone-index');
+      if (!zoneIdxStr) return;
+      const fromIdx = Number(zoneIdxStr);
+      if (isNaN(fromIdx) || fromIdx === i) return;
+      const [moved] = cfg.zones.splice(fromIdx, 1);
+      moved.pct = z.pct;
+      cfg.zones.splice(i, 0, moved);
+      await saveConfig({ zones: cfg.zones });
+      renderZones(active, cfg, staff, save);
+    });
+
     // Highlight color: explicit or from palette
     const explicit = z.color || cfg.zoneColors?.[zName];
     if (explicit) {

--- a/src/ui/builder.ts
+++ b/src/ui/builder.ts
@@ -377,15 +377,16 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
 
     const enableDrop = (container: HTMLElement, pct: boolean) => {
       container.addEventListener('dragover', (e) => e.preventDefault());
-      container.addEventListener('drop', async (e) => {
-        const zoneIdxStr = e.dataTransfer?.getData('zone-index');
-        if (!zoneIdxStr) return;
+      container.addEventListener('drop', async (e: DragEvent) => {
         e.preventDefault();
         e.stopPropagation();
+        const zoneIdxStr = e.dataTransfer?.getData('zone-index');
+        if (!zoneIdxStr) return;
         const fromIdx = Number(zoneIdxStr);
         if (!isNaN(fromIdx)) {
           cfg.zones[fromIdx].pct = pct;
           await saveConfig({ zones: cfg.zones });
+          await save();
           renderZones();
         }
       });


### PR DESCRIPTION
## Summary
- allow dragging zone cards onto other zones on the main board to move between patient care team and assignments
- ensure builder drop targets correctly persist moved zones

## Testing
- `npm test` *(fails: connect ECONNREFUSED)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2be2b3d708327878c2c6bec05175e