### PR TITLE
Sync builder assignments with board settings

### DIFF
--- a/tests/builderConfigSync.spec.ts
+++ b/tests/builderConfigSync.spec.ts
@@ -1,0 +1,72 @@
+/** @vitest-environment happy-dom */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/db', () => {
+  const store: Record<string, any> = {};
+  return {
+    get: async (k: string) => store[k],
+    set: async (k: string, v: any) => {
+      store[k] = v;
+    },
+    del: async (k: string) => {
+      delete store[k];
+    },
+    keys: async () => Object.keys(store),
+  };
+});
+
+vi.mock('@/server', () => ({
+  load: vi.fn().mockImplementation((key: string) => {
+    if (key === 'roster') {
+      return Promise.resolve([{ id: 'n1', role: 'nurse', type: 'home' }]);
+    }
+    return Promise.resolve({});
+  }),
+  save: vi.fn(),
+  softDeleteStaff: vi.fn(),
+  exportHistoryCSV: vi.fn(),
+}));
+
+import { renderBuilder } from '@/ui/builder';
+import { saveConfig, getConfig } from '@/state/config';
+import { STATE } from '@/state/board';
+
+beforeEach(() => {
+  STATE.dateISO = '2024-01-01';
+  STATE.shift = 'day';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.unstubAllGlobals();
+});
+
+describe('builder config sync', () => {
+  it('re-renders when configuration changes', async () => {
+    await saveConfig({ zones: [{ id: 'z1', name: 'Zone A', color: 'var(--panel)' }] });
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    await renderBuilder(root);
+    expect(root.innerHTML).toContain('Zone A');
+    const cfg = getConfig();
+    cfg.zones[0].name = 'Zone B';
+    await saveConfig({ zones: cfg.zones });
+    document.dispatchEvent(new Event('config-changed'));
+    expect(root.innerHTML).toContain('Zone B');
+  });
+
+  it('dispatches config-changed after zone edit', async () => {
+    await saveConfig({ zones: [{ id: 'z1', name: 'Zone A', color: 'var(--panel)' }] });
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    await renderBuilder(root);
+    const handler = vi.fn();
+    document.addEventListener('config-changed', handler);
+    vi.stubGlobal('prompt', vi.fn().mockReturnValue('Zone B'));
+    const editBtn = root.querySelector('.zone-card__actions .btn') as HTMLButtonElement;
+    editBtn.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(handler).toHaveBeenCalled();
+    document.removeEventListener('config-changed', handler);
+  });
+});


### PR DESCRIPTION
## Summary
- listen for `config-changed` events in the shift builder to reload zones and leads
- dispatch `config-changed` when zone assignments change so board/settings stay in sync
- add tests covering builder config synchronization

## Testing
- `npm test` (fails: connect ECONNREFUSED ::1:3000, ENETUNREACH, expected <button id="huddle-btn"> to be null)
- `npx vitest tests/builderConfigSync.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b2c30aaed88327b8f4f83fda1bc1c6