### PR TITLE
feat: capture huddle recorder and detailed history

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,7 +1,7 @@
 # StaffBoard Visual Interface Guide
 
 ## Header
-The top header shows the current shift and date, a large clock, and action buttons to change the theme, open shift huddles or sign out, sync data, refresh, and reset the cache【F:src/ui/header.ts†L40-L55】
+The top header shows the current shift and date, a large clock, and action buttons to change the theme, open shift huddles or sign out, sync data, refresh, and reset the cache【F:src/ui/header.ts†L40-L55】. The Shift Huddle includes a "Completed By" field that lets you select a nurse or enter a name manually.
 
 ## Navigation Tabs
 Below the header, tabs switch between major views: **Board**, **Builder**, **Settings**, and **History**. The Builder tab appears only when enabled by a feature flag【F:src/ui/tabs.ts†L19-L24】
@@ -25,4 +25,4 @@ The calendar view lets you select a date, load or save snapshots, and export sin
 This view allows selecting a nurse, loading their recent shifts into a table, and exporting the results to CSV【F:src/history/NurseHistory.ts†L12-L21】
 
 ### Huddles
-The huddle table lists saved huddle records with an export option for CSV output【F:src/history/HuddleTable.ts†L11-L20】
+The huddle table lists saved huddle records with all checklist items and notes for each entry, plus an export option for CSV output that opens cleanly in spreadsheet tools【F:src/history/HuddleTable.ts†L11-L33】【F:src/history/index.ts†L99-L123】

--- a/src/history/HuddleTable.ts
+++ b/src/history/HuddleTable.ts
@@ -14,7 +14,7 @@ export function renderHuddleTable(root: HTMLElement): void {
         <button id="huddle-export" class="btn">Export CSV</button>
       </div>
       <table class="history-table">
-        <thead><tr><th>Date</th><th>Shift</th><th>By</th><th>Notes</th></tr></thead>
+        <thead><tr><th>Date</th><th>Shift</th><th>By</th><th>Checklist</th><th>Notes</th></tr></thead>
         <tbody id="huddle-body"></tbody>
       </table>
     </div>
@@ -26,10 +26,15 @@ export function renderHuddleTable(root: HTMLElement): void {
   (async () => {
     records = await listHuddles();
     body.innerHTML = records
-      .map(
-        (r) =>
-          `<tr><td>${r.dateISO}</td><td>${r.shift}</td><td>${r.recordedBy}</td><td>${r.notes}</td></tr>`
-      )
+      .map((r) => {
+        const items = r.checklist
+          .map(
+            (i) =>
+              `${i.label}: ${i.state}${i.note ? ` (${i.note})` : ''}`
+          )
+          .join('<br>');
+        return `<tr><td>${r.dateISO}</td><td>${r.shift}</td><td>${r.recordedBy}</td><td>${items}</td><td>${r.notes}</td></tr>`;
+      })
       .join('');
   })();
 


### PR DESCRIPTION
## Summary
- add Completed By field to Shift Huddle dialog with nurse list
- show checklist items and notes in huddle history table and export
- document huddle recorder and detailed history in user guide

## Testing
- `npm test` (fails: signout button modes > omits button when mode=disabled)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2c3af42f48327a58f442f7e2743ca