### PR TITLE
Add welcome how-to modal accessible from Settings

### DIFF
--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -13,6 +13,7 @@ import {
   type ThemePreset,
 } from '@/state/theme';
 import * as Server from '@/server';
+import { openWelcomeModal } from '@/ui/welcome';
 
 function mapIcon(cond: string) {
   const c = (cond || '').toLowerCase();
@@ -227,6 +228,7 @@ function renderGeneralSettings() {
   el.innerHTML = `
     <section class="panel">
       <h3>General</h3>
+      <div class="form-row"><button id="welcome-btn" class="btn">Welcome / How To</button></div>
       ${zonesHTML}
       <div class="form-row"><button id="zone-add" class="btn">Add Zone</button></div>
       <div class="form-row"><label>Day hours <input id="gs-day" type="number" value="${cfg.shiftDurations?.day}"></label></div>
@@ -250,10 +252,12 @@ function renderGeneralSettings() {
       <div class="form-row">
         <label for="gs-sidebar-width">Right Sidebar Width</label>
         <input id="gs-sidebar-width" type="range" min="${ui.rightSidebarMinPx}" max="${ui.rightSidebarMaxPx}" value="${ui.rightSidebarWidthPx}">
-        <input id="gs-sidebar-width-num" type="number" min="${ui.rightSidebarMinPx}" max="${ui.rightSidebarMaxPx}" value="${ui.rightSidebarWidthPx}">
+      <input id="gs-sidebar-width-num" type="number" min="${ui.rightSidebarMinPx}" max="${ui.rightSidebarMaxPx}" value="${ui.rightSidebarWidthPx}">
       </div>
     </section>
   `;
+
+  (document.getElementById('welcome-btn') as HTMLButtonElement).addEventListener('click', openWelcomeModal);
 
   el.querySelectorAll('.zone-sel').forEach((sel) => {
     sel.addEventListener('change', async () => {

--- a/src/ui/welcome.ts
+++ b/src/ui/welcome.ts
@@ -1,0 +1,30 @@
+/** Display a modal with an overview of the application and usage tips. */
+export function openWelcomeModal(): void {
+  if (document.getElementById('welcome-overlay')) return;
+  const overlay = document.createElement('div');
+  overlay.id = 'welcome-overlay';
+  overlay.className = 'manage-overlay';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.innerHTML = `
+    <div class="manage-dialog" style="max-width:400px;">
+      <h3>Welcome to StaffBoard</h3>
+      <p>StaffBoard helps track nurse assignments and shift details.</p>
+      <p>Use the tabs to navigate:</p>
+      <ul>
+        <li><strong>Board</strong> – monitor the live staffing board.</li>
+        <li><strong>Builder</strong> – prepare upcoming shifts.</li>
+        <li><strong>Settings</strong> – manage roster and customize display.</li>
+        <li><strong>History</strong> – review past shifts and huddles.</li>
+      </ul>
+      <div class="dialog-actions">
+        <button id="welcome-close" class="btn">Close</button>
+      </div>
+    </div>`;
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) overlay.remove();
+  });
+  (overlay.querySelector('#welcome-close') as HTMLButtonElement)?.addEventListener('click', () => overlay.remove());
+  document.body.appendChild(overlay);
+  (overlay.querySelector('#welcome-close') as HTMLButtonElement)?.focus();
+}

--- a/tests/welcome.spec.ts
+++ b/tests/welcome.spec.ts
@@ -1,0 +1,11 @@
+/** @vitest-environment happy-dom */
+import { describe, it, expect } from 'vitest';
+import { openWelcomeModal } from '@/ui/welcome';
+
+describe('openWelcomeModal', () => {
+  it('creates the welcome overlay', () => {
+    openWelcomeModal();
+    const el = document.getElementById('welcome-overlay');
+    expect(el).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add welcome/how-to modal popup with basic usage instructions
- add Settings button to open the welcome modal
- cover welcome modal with a unit test

## Testing
- `npm test` *(fails: fetch failed, connection refused)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2c4e59a188327ab588cf3d84719cf