### PR TITLE
Fix patient care team drag-and-drop area

### DIFF
--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -274,6 +274,8 @@ function renderZones(
   const cont = document.getElementById('zones')!;
   pctCont.innerHTML = '';
   cont.innerHTML = '';
+  pctCont.style.minHeight = '40px';
+  cont.style.minHeight = '40px';
   const zones: ZoneDef[] = cfg.zones || [];
 
   zones.forEach((z: ZoneDef, i: number) => {


### PR DESCRIPTION
## Summary
- Keep patient care team zone container droppable by enforcing minimum height

## Testing
- `npm test` (fails: tests/signoutDom.spec.ts omits button when mode=disabled)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2d32b07c08327a343a8cd3313f214