### PR TITLE
feat: record NEDOCS in shift huddle

### DIFF
--- a/src/history/HuddleTable.ts
+++ b/src/history/HuddleTable.ts
@@ -14,7 +14,7 @@ export function renderHuddleTable(root: HTMLElement): void {
         <button id="huddle-export" class="btn">Export CSV</button>
       </div>
       <table class="history-table">
-        <thead><tr><th>Date</th><th>Shift</th><th>By</th><th>Checklist</th><th>Notes</th></tr></thead>
+        <thead><tr><th>Date</th><th>Shift</th><th>By</th><th>NEDOCS</th><th>Checklist</th><th>Notes</th></tr></thead>
         <tbody id="huddle-body"></tbody>
       </table>
     </div>
@@ -33,7 +33,7 @@ export function renderHuddleTable(root: HTMLElement): void {
               `${i.label}: ${i.state}${i.note ? ` (${i.note})` : ''}`
           )
           .join('<br>');
-        return `<tr><td>${r.dateISO}</td><td>${r.shift}</td><td>${r.recordedBy}</td><td>${items}</td><td>${r.notes}</td></tr>`;
+        return `<tr><td>${r.dateISO}</td><td>${r.shift}</td><td>${r.recordedBy}</td><td>${r.nedocs}</td><td>${items}</td><td>${r.notes}</td></tr>`;
       })
       .join('');
   })();

--- a/src/history/index.ts
+++ b/src/history/index.ts
@@ -99,7 +99,7 @@ export function exportNurseHistoryCSV(entries: NurseShiftIndexEntry[]): string {
  */
 export function exportHuddlesCSV(records: HuddleRecord[]): string {
   const ids = DEFAULT_HUDDLE_ITEMS.map((i) => i.id);
-  const header = ['date', 'shift', 'recordedAt', 'recordedBy', 'notes', ...ids].join(
+  const header = ['date', 'shift', 'recordedAt', 'recordedBy', 'nedocs', 'notes', ...ids].join(
     ','
   );
   const rows = records
@@ -118,6 +118,7 @@ export function exportHuddlesCSV(records: HuddleRecord[]): string {
         r.shift,
         r.recordedAtISO,
         r.recordedBy,
+        r.nedocs,
         `"${r.notes.replace(/"/g, '""')}"`,
         ...vals,
       ].join(',');

--- a/src/history/seed.ts
+++ b/src/history/seed.ts
@@ -42,6 +42,7 @@ export async function seedDemoHistory(): Promise<void> {
     shift: 'day',
     recordedAtISO: publishedAt,
     recordedBy: 'demo',
+    nedocs: 0,
     checklist: [],
     notes: 'demo huddle',
   };

--- a/src/state/history.ts
+++ b/src/state/history.ts
@@ -61,6 +61,7 @@ export interface HuddleRecord {
   shift: ShiftKind;
   recordedAtISO: string;
   recordedBy: string;
+  nedocs: number;
   checklist: HuddleChecklistItem[];
   notes: string;
 }

--- a/src/ui/huddle.ts
+++ b/src/ui/huddle.ts
@@ -25,11 +25,14 @@ export async function openHuddle(
       shift,
       recordedAtISO: new Date().toISOString(),
       recordedBy: 'unknown',
+      nedocs: 0,
       checklist: DEFAULT_HUDDLE_ITEMS.map((i) => ({ ...i, state: 'ok' })),
       notes: '',
     };
+  if (record.nedocs === undefined) record.nedocs = 0;
   renderOverlay();
   wireRecorder(staff);
+  wireNedocs();
   renderChecklist();
   wireNotes();
   wireTimer();
@@ -54,6 +57,10 @@ function renderOverlay() {
           <label for="huddle-recorder">Completed By</label>
           <input id="huddle-recorder" class="input" list="huddle-recorder-list">
           <datalist id="huddle-recorder-list"></datalist>
+        </div>
+        <div class="form-row">
+          <label for="huddle-nedocs">NEDOCS Score <a href="https://www.mdcalc.com/calc/3143/nedocs-score-emergency-department-overcrowding" target="_blank" rel="noopener">calc</a></label>
+          <input id="huddle-nedocs" class="input" type="number" min="0" max="200" value="${record.nedocs}">
         </div>
         <div id="huddle-checklist"></div>
         <div>
@@ -135,6 +142,16 @@ function wireRecorder(staff: Staff[]) {
   input.value = record.recordedBy === 'unknown' ? '' : record.recordedBy;
   input.addEventListener('blur', async () => {
     record.recordedBy = input.value || 'unknown';
+    await save();
+  });
+}
+
+function wireNedocs() {
+  const input = document.getElementById('huddle-nedocs') as HTMLInputElement;
+  input.value = String(record.nedocs);
+  input.addEventListener('blur', async () => {
+    const val = parseInt(input.value, 10);
+    record.nedocs = isNaN(val) ? 0 : val;
     await save();
   });
 }

--- a/tests/history.spec.ts
+++ b/tests/history.spec.ts
@@ -113,6 +113,7 @@ describe('history persistence', () => {
       shift: 'day',
       recordedAtISO: '2024-01-01T08:00:00.000Z',
       recordedBy: 'me',
+      nedocs: 0,
       checklist: [{ id: 'airway', label: 'Airway', checked: true }],
       notes: 'all good',
     };
@@ -127,6 +128,7 @@ describe('history persistence', () => {
       shift: 'night',
       recordedAtISO: '2024-01-02T20:00:00.000Z',
       recordedBy: 'me',
+      nedocs: 0,
       checklist: [{ id: 'airway', label: 'Airway', checked: true }],
       notes: 'done',
     };


### PR DESCRIPTION
## Summary
- allow entering NEDOCS score during shift huddle
- export NEDOCS score in huddle history and CSV

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b71497643483278466de51e78deaca