### PR TITLE
Parse physician names from ICS attendees

### DIFF
--- a/tests/physicians.spec.ts
+++ b/tests/physicians.spec.ts
@@ -12,13 +12,10 @@ describe('physician schedule parsing', () => {
       'BEGIN:VCALENDAR',
       'BEGIN:VEVENT',
       'DTSTART:20240101T070000',
-      'SUMMARY:Dr A',
+      'SUMMARY:ER Main Schedule',
       'LOCATION:Jewish Downtown',
-      'END:VEVENT',
-      'BEGIN:VEVENT',
-      'DTSTART:20240101T070000',
-      'SUMMARY:Dr B',
-      'LOCATION:Other',
+      'ATTENDEE;CN=Dr A:mailto:a@example.com',
+      'ATTENDEE;CN=Dr B:mailto:b@example.com',
       'END:VEVENT',
       'END:VCALENDAR',
     ].join('\n');
@@ -29,6 +26,11 @@ describe('physician schedule parsing', () => {
       summary: 'Dr A',
       location: 'Jewish Downtown',
     });
+    expect(events[1]).toEqual({
+      date: '2024-01-01',
+      summary: 'Dr B',
+      location: 'Jewish Downtown',
+    });
   });
 
   it('handles DTSTART with TZID parameter', () => {
@@ -36,8 +38,9 @@ describe('physician schedule parsing', () => {
       'BEGIN:VCALENDAR',
       'BEGIN:VEVENT',
       'DTSTART;TZID=America/New_York:20240101T070000',
-      'SUMMARY:Dr A',
+      'SUMMARY:ER Main Schedule',
       'LOCATION:Jewish Downtown',
+      'ATTENDEE;CN=Dr A:mailto:a@example.com',
       'END:VEVENT',
       'END:VCALENDAR',
     ].join('\n');
@@ -55,23 +58,28 @@ describe('physician schedule parsing', () => {
       'BEGIN:VCALENDAR',
       'BEGIN:VEVENT',
       'DTSTART:20240101T070000',
-      'SUMMARY:Dr A',
+      'SUMMARY:ER Main Schedule',
       'LOCATION:Jewish Downtown',
+      'ATTENDEE;CN=Dr A:mailto:a@example.com',
+      'ATTENDEE;CN=Dr B:mailto:b@example.com',
       'END:VEVENT',
       'BEGIN:VEVENT',
       'DTSTART:20240105T070000',
-      'SUMMARY:Dr B',
+      'SUMMARY:ER Main Schedule',
       'LOCATION:Jewish Downtown',
+      'ATTENDEE;CN=Dr C:mailto:c@example.com',
       'END:VEVENT',
       'BEGIN:VEVENT',
       'DTSTART:20240108T070000',
-      'SUMMARY:Dr C',
+      'SUMMARY:ER Main Schedule',
       'LOCATION:Jewish Downtown',
+      'ATTENDEE;CN=Dr D:mailto:d@example.com',
       'END:VEVENT',
       'BEGIN:VEVENT',
       'DTSTART:20240103T070000',
-      'SUMMARY:Dr D',
+      'SUMMARY:ER Main Schedule',
       'LOCATION:Other',
+      'ATTENDEE;CN=Dr E:mailto:e@example.com',
       'END:VEVENT',
       'END:VCALENDAR',
     ].join('\n');
@@ -86,8 +94,8 @@ describe('physician schedule parsing', () => {
 
     const res = await getUpcomingDoctors('2024-01-01', 7);
     expect(res).toEqual({
-      '2024-01-01': ['Dr A'],
-      '2024-01-05': ['Dr B'],
+      '2024-01-01': ['Dr A', 'Dr B'],
+      '2024-01-05': ['Dr C'],
     });
 
     // Ensure we used the direct fetch at least once


### PR DESCRIPTION
## Summary
- Extract physician names from ICS `ATTENDEE` entries when schedule summaries are generic
- Update physician parsing tests to cover attendee-based events and grouping

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b728bed81c8327a754138f81d3f364