### PR TITLE
Persist board zone changes

### DIFF
--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -156,6 +156,8 @@ export async function renderBoard(
     // Re-render on config changes (e.g., zone list or colors)
     document.addEventListener('config-changed', () => {
       const c = getConfig();
+      normalizeActiveZones(active, c.zones);
+      queueSave();
       renderLeadership(active, staff, queueSave);
       renderZones(active, c, staff, queueSave);
     });


### PR DESCRIPTION
## Summary
- keep main board in sync with zone configuration updates

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b73ca0ce8c83278dd3656a45e3ab51