### PR TITLE
chore: remove default zone seeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- fix: stop seeding default zones so board starts empty
 - fix: normalize zone definitions and guard against invalid data
 - fix: prevent full app re-render on clock tick to stop input focus loss; throttle weather updates.
 - feat: seed defaults via `staff_and_zones.json` and `seedDefaults()`; enforce canonical zones.

--- a/src/seedDefaults.ts
+++ b/src/seedDefaults.ts
@@ -1,25 +1,11 @@
 import data from '../staff_and_zones.json';
-import { getConfig, saveConfig, loadStaff, saveStaff, Staff } from '@/state';
+import { loadStaff, saveStaff, Staff } from '@/state';
 import { ensureStaffId } from '@/utils/id';
-import type { ZoneDef } from '@/utils/zones';
 
-export const CANONICAL_ZONES: ZoneDef[] = data.zones as ZoneDef[];
-
-/** Seed default staff and zones if none exist. Idempotent. */
+/** Seed default staff if none exist. Idempotent. */
 export async function seedDefaults(): Promise<void> {
-  const cfg = getConfig();
-  if (!cfg.zones || cfg.zones.length === 0) {
-    await saveConfig({ zones: [...CANONICAL_ZONES] });
-  } else {
-    const merged = [...cfg.zones];
-    for (const z of CANONICAL_ZONES) {
-      if (!merged.some((m) => m.id === z.id || m.name === z.name)) merged.push(z);
-    }
-    await saveConfig({ zones: merged });
-  }
-
   let staff = await loadStaff();
-  if (staff.length === 0) {
+  if (staff.length === 0 && Array.isArray(data.staff)) {
     staff = data.staff.map((s) => ({ ...s, id: ensureStaffId(s.id) })) as Staff[];
     await saveStaff(staff);
   }

--- a/staff_and_zones.json
+++ b/staff_and_zones.json
@@ -1,14 +1,5 @@
 {
   "version": 1,
-  "zones": [
-    { "id": "z-01", "name": "Rooms 1-7 & 10", "color": "#f6e5f5" },
-    { "id": "z-02", "name": "Rooms 8-12", "color": "#e5f0ff" },
-    { "id": "z-03", "name": "Rooms 13-16", "color": "#e5fff8" },
-    { "id": "z-04", "name": "Rooms 17-20", "color": "#fffbe5" },
-    { "id": "z-05", "name": "Rooms 21-24", "color": "#ffe5e5" },
-    { "id": "z-06", "name": "Faster", "color": "#e5ffe5" },
-    { "id": "z-07", "name": "Cardiac Obs", "color": "#e5e5ff" }
-  ],
   "staff": [
     { "id": "00-aaaaaa-001", "name": "Alice Nurse", "role": "nurse" },
     { "id": "00-bbbbbb-001", "name": "Bob Tech", "role": "tech" }


### PR DESCRIPTION
## Summary
- stop seeding zones on startup so the board starts empty
- remove zone data from staff_and_zones.json

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b76f2c3820832793ca08644d1bc9d5