### PR TITLE
feat: prevent zone rename collisions

### DIFF
--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -333,6 +333,10 @@ function renderZones(
     editBtn.addEventListener('click', async () => {
       const val = prompt('Rename zone', z.name)?.trim();
       if (val && val !== z.name) {
+        if (cfg.zones.some((zz) => zz.name === val)) {
+          alert('A zone with that name already exists.');
+          return;
+        }
         const idx = cfg.zones.findIndex((zz) => zz.name === z.name);
         cfg.zones[idx].name = val;
         if (cfg.zoneColors && cfg.zoneColors[z.name]) {

--- a/src/ui/builder.ts
+++ b/src/ui/builder.ts
@@ -260,6 +260,10 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
       editBtn.addEventListener('click', async () => {
         const val = prompt('Rename zone', z.name)?.trim();
         if (val && val !== z.name) {
+          if (cfg.zones.some((zz) => zz.name === val)) {
+            alert('A zone with that name already exists.');
+            return;
+          }
           const idx = cfg.zones.findIndex((zz) => zz.name === z.name);
           cfg.zones[idx].name = val;
           if (cfg.zoneColors && cfg.zoneColors[z.name]) {


### PR DESCRIPTION
## Summary
- avoid overwriting zone assignments when renaming to an existing zone name by rejecting duplicates in zone editor and board

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b82f9779508327abb452a71c479028