### PR TITLE
Default audit when updating legacy shift snapshots

### DIFF
--- a/src/state/history.ts
+++ b/src/state/history.ts
@@ -140,8 +140,9 @@ export async function savePublishedShift(
   );
   const now = new Date().toISOString();
   if (existing) {
+    const baseAudit = existing.audit || { createdAtISO: now, createdBy: user };
     snapshot.audit = {
-      ...existing.audit,
+      ...baseAudit,
       mutatedAtISO: now,
       mutatedBy: user,
       reason,

--- a/tests/history.spec.ts
+++ b/tests/history.spec.ts
@@ -60,6 +60,18 @@ describe('history persistence', () => {
     expect(loaded?.audit.reason).toBe('fix');
   });
 
+  it('defaults audit when existing snapshot lacks audit', async () => {
+    const key = 'history:shift:2024-01-01:day';
+    const legacy = { ...base } as any;
+    delete legacy.audit;
+    store[key] = legacy;
+    const updated = { ...legacy, comments: 'y' };
+    await savePublishedShift(updated, 'tester', 'legacy');
+    const loaded = await getShiftByDate('2024-01-01', 'day');
+    expect(loaded?.audit.mutatedBy).toBe('tester');
+    expect(loaded?.audit.createdAtISO).toBeDefined();
+  });
+
   it('indexes staff assignments', async () => {
     const snap: PublishedShiftSnapshot = {
       ...base,


### PR DESCRIPTION
## Summary
- avoid TypeError when updating legacy shift snapshots lacking audit info
- add regression test for missing audit case in savePublishedShift

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8414423988327918c58c33be0a934