### PR TITLE
Improve persistence and cross-tab sync

### DIFF
--- a/src/state/sync.ts
+++ b/src/state/sync.ts
@@ -1,0 +1,26 @@
+/**
+ * Simple cross-tab synchronization using BroadcastChannel.
+ */
+const channel: BroadcastChannel | null =
+  typeof BroadcastChannel === 'undefined'
+    ? null
+    : new BroadcastChannel('staffboard-sync');
+
+/**
+ * Notify other tabs that a key has been updated.
+ * @param key Storage key that changed.
+ */
+export function notifyUpdate(key: string): void {
+  channel?.postMessage({ key });
+}
+
+/**
+ * Listen for updates to a given key.
+ * @param key Storage key to watch.
+ * @param handler Callback when the key is updated.
+ */
+export function onUpdate(key: string, handler: () => void): void {
+  channel?.addEventListener('message', (ev) => {
+    if (ev.data?.key === key) handler();
+  });
+}


### PR DESCRIPTION
## Summary
- Save drafts to server, auto-save on tab change, and broadcast updates to other tabs
- Synchronize active board changes across tabs with BroadcastChannel
- Migrate legacy drafts to current schema

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b84167205c83279acee37fc7406bd2