### PR TITLE
fix: guard weather panel element

### DIFF
--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -156,7 +156,8 @@ export async function renderBoard(
     wireComments(active, queueSave);
     await renderIncoming(active, queueSave);
     renderOffgoing(active, queueSave);
-    await renderWeather(document.getElementById('weather-body')!);
+    const weatherBody = document.getElementById('weather-body');
+    if (weatherBody) await renderWeather(weatherBody);
     await renderPhysicians(
       document.getElementById('phys') as HTMLElement,
       ctx.dateISO


### PR DESCRIPTION
## Summary
- avoid null reference when rendering weather widget

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9abebcb108327b50b92acd5d7923a