### PR TITLE
feat: lock predefined zones

### DIFF
--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -381,24 +381,6 @@ function renderZones(
     });
     actions.appendChild(editBtn);
 
-    const delBtn = document.createElement('button');
-    delBtn.textContent = 'Delete';
-    delBtn.className = 'btn';
-    delBtn.addEventListener('click', async () => {
-      if (!confirm(`Delete zone ${z.name}?`)) return;
-      const idx = cfg.zones.findIndex((zz) => zz.name === z.name);
-      const removed = cfg.zones.splice(idx, 1)[0];
-      if (removed) {
-        delete active.zones[removed.name];
-        if (cfg.zoneColors) delete cfg.zoneColors[removed.name];
-      }
-      await saveConfig({ zones: cfg.zones, zoneColors: cfg.zoneColors });
-      document.dispatchEvent(new Event('config-changed'));
-      await save();
-      renderZones(active, cfg, staff, save);
-    });
-    actions.appendChild(delBtn);
-
     section.appendChild(actions);
 
     const body = document.createElement('div');

--- a/src/ui/builder.ts
+++ b/src/ui/builder.ts
@@ -307,24 +307,6 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
       });
       actions.appendChild(editBtn);
 
-      const delBtn = document.createElement('button');
-      delBtn.textContent = 'Delete';
-      delBtn.className = 'btn';
-      delBtn.addEventListener('click', async () => {
-        if (!confirm(`Delete zone ${z.name}?`)) return;
-        const idx = cfg.zones.findIndex((zz) => zz.name === z.name);
-        const removed = cfg.zones.splice(idx, 1)[0];
-        if (removed) {
-          delete board.zones[removed.name];
-          if (cfg.zoneColors) delete cfg.zoneColors[removed.name];
-        }
-        await saveConfig({ zones: cfg.zones, zoneColors: cfg.zoneColors });
-        document.dispatchEvent(new Event('config-changed'));
-        await save();
-        renderZones();
-      });
-      actions.appendChild(delBtn);
-
       section.appendChild(actions);
 
       const body = document.createElement('div');

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -221,7 +221,6 @@ function renderGeneralSettings() {
         `<div class="form-row zone-row">
           <input class="zone-name" data-index="${i}" value="${z.name}">
           ${zoneOptions(z.name, z.color)}
-          <button class="zone-del btn" data-index="${i}">Remove</button>
         </div>`
     )
     .join('');
@@ -230,7 +229,6 @@ function renderGeneralSettings() {
       <h3>General</h3>
       <div class="form-row"><button id="welcome-btn" class="btn">Welcome / How To</button></div>
       ${zonesHTML}
-      <div class="form-row"><button id="zone-add" class="btn">Add Zone</button></div>
       <div class="form-row"><label>Day hours <input id="gs-day" type="number" value="${cfg.shiftDurations?.day}"></label></div>
       <div class="form-row"><label>Night hours <input id="gs-night" type="number" value="${cfg.shiftDurations?.night}"></label></div>
       <div class="form-row"><label>DTO minutes <input id="gs-dto" type="number" value="${cfg.dtoMinutes}"></label></div>
@@ -286,22 +284,6 @@ function renderGeneralSettings() {
         renderGeneralSettings();
       }
     });
-  });
-  el.querySelectorAll('.zone-del').forEach((btn) => {
-    btn.addEventListener('click', async () => {
-      const idx = Number((btn as HTMLElement).getAttribute('data-index'));
-      const removed = cfg.zones.splice(idx, 1)[0];
-      if (removed && cfg.zoneColors) delete cfg.zoneColors[removed.name];
-      await saveConfig({ zones: cfg.zones, zoneColors: cfg.zoneColors });
-      document.dispatchEvent(new Event('config-changed'));
-      renderGeneralSettings();
-    });
-  });
-  (document.getElementById('zone-add') as HTMLButtonElement).addEventListener('click', async () => {
-    cfg.zones.push({ id: `zone_${Date.now()}`, name: `Zone ${cfg.zones.length + 1}`, color: 'var(--panel)' });
-    await saveConfig({ zones: cfg.zones });
-    document.dispatchEvent(new Event('config-changed'));
-    renderGeneralSettings();
   });
   (document.getElementById('gs-day') as HTMLInputElement).addEventListener('change', async (e) => {
     cfg.shiftDurations!.day = parseInt((e.target as HTMLInputElement).value) || 12;


### PR DESCRIPTION
## Summary
- seed board with fixed Charge, Triage, and unit assignments plus room and tech zones
- drop UI controls for adding or deleting zones; only renaming and reordering remain
- adjust seeding to handle fixed zones without dynamic unassigned bucket

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9ac93d2b08327a5c15401d9f36e2b