### PR TITLE
Handle all PCT zones in seed board

### DIFF
--- a/src/seed.ts
+++ b/src/seed.ts
@@ -60,12 +60,12 @@ export function buildSeedBoard(
   settings: SeedSettings = DEFAULT_SEED_SETTINGS
 ): Board {
   const cfg = getConfig();
-    const board: Board = {
-      charge: undefined,
-      triage: undefined,
-      admin: undefined,
-      zones: Object.fromEntries((cfg.zones || []).map((z) => [z.name, [] as Slot[]])),
-    };
+  const board: Board = {
+    charge: undefined,
+    triage: undefined,
+    admin: undefined,
+    zones: Object.fromEntries((cfg.zones || []).map((z) => [z.name, [] as Slot[]])),
+  };
 
   if (settings.assignChargeTriage) {
     const chargeCand = roster.find((n) => n.eligibleRoles?.includes('charge'));
@@ -80,7 +80,11 @@ export function buildSeedBoard(
     if (adminCand) board.admin = { nurseId: adminCand.id };
   }
 
-  const defaultZone = cfg.zones.find((z) => !z.pct)?.name;
+  let defaultZone = cfg.zones.find((z) => !z.pct)?.name;
+  if (!defaultZone) {
+    defaultZone = 'Unassigned';
+    board.zones[defaultZone] = [];
+  }
   for (const n of roster) {
     if (board.charge?.nurseId === n.id || board.triage?.nurseId === n.id) continue;
     if (
@@ -89,7 +93,7 @@ export function buildSeedBoard(
       cfg.zones.some((z) => z.name === n.defaultZone)
     ) {
       board.zones[n.defaultZone].push({ nurseId: n.id });
-    } else if (defaultZone) {
+    } else {
       board.zones[defaultZone].push({ nurseId: n.id });
     }
   }

--- a/tests/seedZones.spec.ts
+++ b/tests/seedZones.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/state', () => ({
+  getConfig: () => ({
+    zones: [
+      { name: 'Charge Nurse', pct: true },
+      { name: 'Triage Nurse', pct: true },
+    ],
+  }),
+}));
+
+import { buildSeedBoard, DEFAULT_SEED_SETTINGS } from '@/seed';
+
+describe('buildSeedBoard with all PCT zones', () => {
+  it('adds an Unassigned zone for unplaced staff', () => {
+    const roster = [
+      { id: 'n1', name: 'n1', role: 'nurse', type: 'other' } as any,
+    ];
+    const board = buildSeedBoard(roster, {
+      ...DEFAULT_SEED_SETTINGS,
+      assignChargeTriage: false,
+    });
+    expect(board.zones.Unassigned).toBeDefined();
+    expect(board.zones.Unassigned[0]).toEqual({ nurseId: 'n1' });
+  });
+});


### PR DESCRIPTION
## Summary
- Add fallback "Unassigned" zone when no non-PCT zone exists during seed board creation
- Cover all-PCT configuration with new unit test

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9b200f78083278702bebf0b9125d2