### PR TITLE
style: compact zone edit and history toast

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,8 +23,12 @@ import { renderSettings } from '@/ui/settings';
 import { renderBuilder } from '@/ui/builder';
 import { renderHistoryTab } from '@/ui/historyTab';
 import { outlineBlockers } from '@/utils/debug';
-import { showBanner } from '@/ui/banner';
+import { showBanner, showToast } from '@/ui/banner';
 import * as Server from '@/server';
+
+document.addEventListener('history-saved', () =>
+  showToast('assignments saved to history')
+);
 
 export async function renderAll() {
   applyTheme();

--- a/src/state/board.ts
+++ b/src/state/board.ts
@@ -221,6 +221,9 @@ export async function applyDraftToActive(
   };
   await savePublishedShift(snapshot);
   await indexStaffAssignments(snapshot);
+  if (typeof document !== 'undefined') {
+    document.dispatchEvent(new Event('history-saved'));
+  }
 }
 
 export { DB };

--- a/src/styles.css
+++ b/src/styles.css
@@ -222,6 +222,7 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .manage-dialog label{display:flex;flex-direction:column;gap:4px}
 .manage-dialog .dialog-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:8px}
 .banner{background:var(--danger);color:var(--text);padding:8px;text-align:center}
+.toast{position:fixed;top:16px;right:16px;background:rgba(0,0,0,.6);color:var(--text);padding:8px 12px;border-radius:8px;z-index:var(--z-modal)}
 
 .phys-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:var(--z-modal)}
 .phys-modal{background:var(--panel);padding:16px;border-radius:8px;max-width:320px;max-height:80vh;overflow:auto}

--- a/src/ui/banner.ts
+++ b/src/ui/banner.ts
@@ -15,3 +15,20 @@ export function showBanner(msg: string): void {
     el?.remove();
   }, 10_000);
 }
+
+let toastTimer: number | undefined;
+
+export function showToast(msg: string): void {
+  let el = document.getElementById('app-toast');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'app-toast';
+    el.className = 'toast';
+    document.body.appendChild(el);
+  }
+  el.textContent = msg;
+  if (toastTimer) clearTimeout(toastTimer);
+  toastTimer = window.setTimeout(() => {
+    el?.remove();
+  }, 4_000);
+}

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -353,12 +353,9 @@ function renderZones(
     title.textContent = zName;
     section.appendChild(title);
 
-    const actions = document.createElement('div');
-    actions.className = 'zone-card__actions';
-
     const editBtn = document.createElement('button');
-    editBtn.textContent = 'Edit';
-    editBtn.className = 'btn';
+    editBtn.textContent = '⚙';
+    editBtn.className = 'zone-card__edit';
     editBtn.addEventListener('click', async () => {
       const val = prompt('Rename zone', z.name)?.trim();
       if (val && val !== z.name) {
@@ -380,9 +377,7 @@ function renderZones(
         renderZones(active, cfg, staff, save);
       }
     });
-    actions.appendChild(editBtn);
-
-    section.appendChild(actions);
+    section.appendChild(editBtn);
 
     const body = document.createElement('div');
     body.className = 'zone-card__body';

--- a/src/ui/builder.ts
+++ b/src/ui/builder.ts
@@ -263,6 +263,13 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
       section.className = 'zone-card';
       section.draggable = true;
       section.dataset.index = String(i);
+      const explicit = z.color || cfg.zoneColors?.[z.name];
+      if (explicit) {
+        section.style.setProperty('--zone-color', explicit);
+      } else {
+        const zi = (i % 8) + 1;
+        section.style.setProperty('--zone-color', `var(--zone-bg-${zi})`);
+      }
       section.addEventListener('dragstart', (e) => {
         if ((e.target as HTMLElement).closest('.nurse-row')) return;
         const ev = e as DragEvent;
@@ -278,12 +285,9 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
       title.textContent = z.name;
       section.appendChild(title);
 
-      const actions = document.createElement('div');
-      actions.className = 'zone-card__actions';
-
       const editBtn = document.createElement('button');
-      editBtn.textContent = 'Edit';
-      editBtn.className = 'btn';
+      editBtn.textContent = '⚙';
+      editBtn.className = 'zone-card__edit';
       editBtn.addEventListener('click', async () => {
         const val = prompt('Rename zone', z.name)?.trim();
         if (val && val !== z.name) {
@@ -305,9 +309,7 @@ export async function renderBuilder(root: HTMLElement): Promise<void> {
           renderZones();
         }
       });
-      actions.appendChild(editBtn);
-
-      section.appendChild(actions);
+      section.appendChild(editBtn);
 
       const body = document.createElement('div');
       body.className = 'zone-card__body';

--- a/src/ui/mainBoard/boardLayout.css
+++ b/src/ui/mainBoard/boardLayout.css
@@ -1,7 +1,6 @@
 .zone-card{position:relative;background:var(--panel);color:var(--text-high);border:1px solid var(--card-border);border-radius:16px;padding:16px;box-shadow:var(--shadow);}
 .zone-card::before{content:"";position:absolute;top:0;left:0;right:0;height:6px;background:var(--zone-color,var(--zone-bg-1));border-top-left-radius:16px;border-top-right-radius:16px;}
 .zone-card__title{font-weight:700;font-size:clamp(1.25rem,1.2rem + 0.4vw,1.5rem);margin:0 0 12px 0;letter-spacing:-.2px;}
-.zone-card__actions{display:flex;gap:8px;margin-bottom:12px;}
 .zone-card__body{display:flex;flex-direction:column;gap:10px;overflow-y:auto;min-height:60px;padding:10px;}
 .zone-card__body:empty{border:2px dashed var(--card-border);border-radius:8px;}
 .nurse-row{display:flex;align-items:center;gap:8px;}
@@ -11,4 +10,5 @@
 .nurse-card__name{font-weight:600;font-size:clamp(1.05rem,1rem + 0.3vw,1.25rem);line-height:1.2;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .nurse-card__meta{color:var(--text-med);font-size:.85em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .nurse-card:focus-visible{outline:2px solid var(--ring);outline-offset:2px;}
+.zone-card__edit{position:absolute;top:8px;right:8px;background:none;border:none;cursor:pointer}
 

--- a/tests/builderConfigSync.spec.ts
+++ b/tests/builderConfigSync.spec.ts
@@ -63,7 +63,7 @@ describe('builder config sync', () => {
     const handler = vi.fn();
     document.addEventListener('config-changed', handler);
     vi.stubGlobal('prompt', vi.fn().mockReturnValue('Zone B'));
-    const editBtn = root.querySelector('.zone-card__actions .btn') as HTMLButtonElement;
+    const editBtn = root.querySelector('.zone-card__edit') as HTMLButtonElement;
     editBtn.click();
     await new Promise((r) => setTimeout(r, 0));
     expect(handler).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- align builder zone display with board by applying zone colors
- swap bulky zone edit button for a subtle cog icon
- show a transparent toast once assignments are saved to history

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9b4bf57e48327b18e93cddebc77ab