### PR TITLE
style: add outer padding for large displays

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -86,6 +86,7 @@
 html,body{height:100%;overflow:auto}
 body{margin:0;background:var(--bg);color:var(--text-high);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
 .wrap{width:100%;padding:var(--gap)}
+#app{padding:clamp(18px,3vw,64px);}
 header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-items:center;margin-bottom:var(--gap);position:sticky;top:0;z-index:var(--z-sticky);background:var(--bg)}
 .title{font-size:var(--f-xl);font-weight:800;letter-spacing:.2px}
 .subtitle{color:var(--text-muted);font-size:var(--f)}


### PR DESCRIPTION
## Summary
- add responsive outer padding to app container so tabs and content stay in view on large displays

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba372884b88327a84ed77b9e790607