### PR TITLE
Ensure manage overlay persists roster before closing

### DIFF
--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -677,7 +677,7 @@ function manageSlot(
     rerender();
   });
 
-  overlay.querySelector('#mg-save')!.addEventListener('click', () => {
+  overlay.querySelector('#mg-save')!.addEventListener('click', async () => {
     // Basic fields
     st.name = (overlay.querySelector('#mg-name') as HTMLInputElement).value.trim() || undefined;
 
@@ -718,8 +718,8 @@ function manageSlot(
     }
 
     // Persist
-    saveStaff(staffList); // best-effort staff write
-    save();               // board tuple
+    await saveStaff(staffList); // best-effort staff write
+    save();
     overlay.remove();
     rerender();
   });

--- a/tests/manageOverlayPersist.spec.ts
+++ b/tests/manageOverlayPersist.spec.ts
@@ -1,0 +1,75 @@
+/** @vitest-environment happy-dom */
+import { describe, it, expect, vi } from 'vitest';
+
+let resolveSave: () => void;
+vi.mock('@/state', () => {
+  const KS = {
+    STAFF: 'STAFF',
+    HISTORY: 'HISTORY',
+    ACTIVE: (d: string, s: string) => `ACTIVE:${d}:${s}`,
+    DRAFT: (d: string, s: string) => `DRAFT:${d}:${s}`,
+  };
+  const STATE = { dateISO: '2024-01-01', shift: 'day', clockHHMM: '07:00', locked: false };
+  const store: Record<string, any> = {
+    [KS.ACTIVE(STATE.dateISO, STATE.shift)]: {
+      dateISO: STATE.dateISO,
+      shift: STATE.shift,
+      charge: undefined,
+      triage: undefined,
+      admin: undefined,
+      zones: { 'Zone A': [{ nurseId: 'n1' }] },
+      incoming: [],
+      offgoing: [],
+      comments: '',
+      huddle: '',
+      handoff: '',
+      version: 1,
+    },
+  };
+  const loadStaff = async () => [{ id: 'n1', name: 'Alice', role: 'nurse', type: 'home' }];
+  const saveStaff = vi.fn(() => new Promise<void>((r) => { resolveSave = r; }));
+  return {
+    STATE,
+    KS,
+    loadStaff,
+    saveStaff,
+    CURRENT_SCHEMA_VERSION: 1,
+    migrateActiveBoard: (a: any) => a,
+    setActiveBoardCache: () => {},
+    DB: {
+      get: async (k: string) => store[k],
+      set: async (k: string, v: any) => { store[k] = v; },
+    },
+    getConfig: () => ({ zones: [{ name: 'Zone A', color: 'var(--panel)' }] }),
+    saveConfig: async () => {},
+  };
+});
+
+vi.mock('@/server', () => ({ load: vi.fn(), save: vi.fn() }));
+vi.mock('@/ui/widgets', () => ({ renderWeather: vi.fn() }));
+vi.mock('@/ui/physicians', () => ({ renderPhysicians: vi.fn(), renderPhysicianPopup: vi.fn() }));
+vi.mock('@/ui/assignDialog', () => ({ openAssignDialog: vi.fn() }));
+vi.mock('@/ui/banner', () => ({ showBanner: vi.fn(), showToast: vi.fn() }));
+
+import { renderBoard } from '@/ui/board';
+import { saveStaff } from '@/state';
+
+describe('manage overlay', () => {
+  it('waits for roster save before closing', async () => {
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    await renderBoard(root, { dateISO: '2024-01-01', shift: 'day' });
+
+    const manageBtn = root.querySelector('.zone-card .btn') as HTMLButtonElement;
+    manageBtn.click();
+
+    const overlay = document.querySelector('.manage-overlay')!;
+    const saveBtn = overlay.querySelector('#mg-save') as HTMLButtonElement;
+    saveBtn.click();
+    expect(document.querySelector('.manage-overlay')).toBeTruthy();
+    resolveSave();
+    await Promise.resolve();
+    expect(saveStaff).toHaveBeenCalled();
+    expect(document.querySelector('.manage-overlay')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- await `saveStaff` in manage overlay so roster changes survive refresh
- add regression test for manage overlay persistence

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba378aa5788327899a55b0d0d7405f