### PR TITLE
Parse physician names from calendar descriptions

### DIFF
--- a/src/ui/physicians.ts
+++ b/src/ui/physicians.ts
@@ -72,12 +72,20 @@ function parseICS(text: string): Event[] {
             for (const name of attendees) {
               events.push({ date: dateISO, summary: name, location });
             }
+          } else if (current.DESCRIPTION) {
+            const desc = icsUnescape(String(current.DESCRIPTION));
+            const names = desc
+              .split(/\r?\n|,|;/)
+              .map((s) => s.trim())
+              .filter((s) => s && !/er\s*main\s*schedule/i.test(s));
+            for (const name of names) {
+              events.push({ date: dateISO, summary: name, location });
+            }
           } else if (current.SUMMARY) {
-            events.push({
-              date: dateISO,
-              summary: icsUnescape(String(current.SUMMARY)).trim(),
-              location,
-            });
+            const sum = icsUnescape(String(current.SUMMARY)).trim();
+            if (!/er\s*main\s*schedule/i.test(sum)) {
+              events.push({ date: dateISO, summary: sum, location });
+            }
           }
         }
       }

--- a/tests/physicians.spec.ts
+++ b/tests/physicians.spec.ts
@@ -53,6 +53,31 @@ describe('physician schedule parsing', () => {
     });
   });
 
+  it('falls back to DESCRIPTION when attendees missing', () => {
+    const sample = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'DTSTART:20240102T070000',
+      'SUMMARY:ER Main Schedule',
+      'LOCATION:Jewish Downtown',
+      'DESCRIPTION:Dr A\\nDr B',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\n');
+    const events = __test.parseICS(sample);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({
+      date: '2024-01-02',
+      summary: 'Dr A',
+      location: 'Jewish Downtown',
+    });
+    expect(events[1]).toEqual({
+      date: '2024-01-02',
+      summary: 'Dr B',
+      location: 'Jewish Downtown',
+    });
+  });
+
   it('converts UTC timestamps to the local date', () => {
     const expected = (() => {
       const base = new Date(Date.UTC(2024, 0, 1, 0, 0, 0));


### PR DESCRIPTION
## Summary
- parse physician names from DESCRIPTION fields when calendar events lack attendee entries and ignore generic 'ER Main Schedule' summaries
- add regression test for description-based parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba3bd5f68c8327abfa43a82eaa0a60