### PR TITLE
Handle DTSTART values missing seconds

### DIFF
--- a/src/ui/physicians.ts
+++ b/src/ui/physicians.ts
@@ -38,7 +38,7 @@ function unfoldICSLines(text: string): string[] {
  */
 function extractDateISO(dtstart: string): string | null {
   const val = dtstart.includes(':') ? dtstart.split(':', 2)[1] : dtstart;
-  const m = /^(\d{4})(\d{2})(\d{2})(T(\d{2})(\d{2})(\d{2})(Z)?)?/i.exec(
+  const m = /^(\d{4})(\d{2})(\d{2})(T(\d{2})(\d{2})(\d{2})?(Z)?)?/i.exec(
     val.trim()
   );
   if (!m) return null;

--- a/tests/physicians.spec.ts
+++ b/tests/physicians.spec.ts
@@ -11,7 +11,7 @@ describe('physician schedule parsing', () => {
     const sample = [
       'BEGIN:VCALENDAR',
       'BEGIN:VEVENT',
-      'DTSTART:20240101T070000',
+      'DTSTART:20240101T0700',
       'SUMMARY:ER Main Schedule',
       'LOCATION:Jewish Downtown',
       'ATTENDEE;CN=Dr A:mailto:a@example.com',
@@ -86,6 +86,11 @@ describe('physician schedule parsing', () => {
       return local.toISOString().slice(0, 10);
     })();
     expect(__test.extractDateISO('20240101T000000Z')).toBe(expected);
+    expect(__test.extractDateISO('20240101T0000Z')).toBe(expected);
+  });
+
+  it('handles DATE-TIME values without seconds', () => {
+    expect(__test.extractDateISO('20240101T0700')).toBe('2024-01-01');
   });
 
   it('groups upcoming physicians by date (range, location-filtered)', async () => {


### PR DESCRIPTION
## Summary
- Allow extractDateISO to parse iCalendar DATE-TIME strings without seconds
- Cover no-second DTSTART cases in physician schedule tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba3eba009c8327b1fc6377dfc97a50