### PR TITLE
feat: preserve remote changes during sync

### DIFF
--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -8,6 +8,7 @@ import {
   KS,
   getActiveBoardCache,
   setActiveBoardCache,
+  mergeBoards,
   type ActiveBoard,
   type Staff,
 } from '@/state';
@@ -81,9 +82,7 @@ export function renderHeader() {
           date: STATE.dateISO,
           shift,
         });
-        const merged: ActiveBoard = remote
-          ? { ...remote, ...local, zones: { ...(remote.zones || {}), ...(local.zones || {}) } }
-          : local;
+        const merged: ActiveBoard = remote ? mergeBoards(remote, local) : local;
         await DB.set(KS.ACTIVE(STATE.dateISO, shift), merged);
         setActiveBoardCache(merged);
         tasks.push(Server.save('active', merged));

--- a/tests/mergeBoards.spec.ts
+++ b/tests/mergeBoards.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mergeBoards,
+  CURRENT_SCHEMA_VERSION,
+  type ActiveBoard,
+} from '@/state';
+
+const base = (): ActiveBoard => ({
+  dateISO: '2024-01-01',
+  shift: 'day',
+  zones: {},
+  incoming: [],
+  offgoing: [],
+  comments: '',
+  huddle: '',
+  handoff: '',
+  version: CURRENT_SCHEMA_VERSION,
+});
+
+describe('mergeBoards', () => {
+  it('preserves remote comments when local empty', () => {
+    const remote = { ...base(), comments: 'server' };
+    const local = base();
+    const merged = mergeBoards(remote, local);
+    expect(merged.comments).toBe('server');
+  });
+
+  it('keeps remote slots and adds local ones', () => {
+    const remote = { ...base(), zones: { A: [{ nurseId: 'n1' }] } };
+    const local = {
+      ...base(),
+      zones: { A: [{ nurseId: 'n1' }, { nurseId: 'n2' }] },
+    };
+    const merged = mergeBoards(remote, local);
+    expect(merged.zones.A.map((s) => s.nurseId)).toEqual(['n1', 'n2']);
+  });
+
+  it('does not drop remote slots when local zone empty', () => {
+    const remote = { ...base(), zones: { A: [{ nurseId: 'n1' }] } };
+    const local = { ...base(), zones: { A: [] } };
+    const merged = mergeBoards(remote, local);
+    expect(merged.zones.A).toHaveLength(1);
+    expect(merged.zones.A[0].nurseId).toBe('n1');
+  });
+
+  it('merges incoming arrays by nurse and eta', () => {
+    const remote = { ...base(), incoming: [{ nurseId: 'n1', eta: '1' }] };
+    const local = { ...base(), incoming: [{ nurseId: 'n2', eta: '2' }] };
+    const merged = mergeBoards(remote, local);
+    expect(merged.incoming).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add mergeBoards helper to merge local board into server without clobbering remote edits
- update header sync button to use mergeBoards
- add unit tests for mergeBoards behavior

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba3f441f808327856c544e6fa27e07