### PR TITLE
fix: preserve remote metadata when merging arrays

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -146,10 +146,20 @@ export function mergeBoards(remote: ActiveBoard, local: ActiveBoard): ActiveBoar
   merged.huddle = remote.huddle || local.huddle;
   merged.handoff = remote.handoff || local.handoff;
 
-  const mergeArr = <T>(a: T[], b: T[], key: (item: T) => string): T[] => {
+  const mergeArr = <T extends Record<string, unknown>>(
+    a: T[],
+    b: T[],
+    key: (item: T) => string
+  ): T[] => {
     const map = new Map<string, T>();
-    for (const item of a) map.set(key(item), item);
-    for (const item of b) map.set(key(item), item);
+    for (const item of b) {
+      map.set(key(item), item);
+    }
+    for (const item of a) {
+      const k = key(item);
+      const existing = map.get(k);
+      map.set(k, existing ? { ...existing, ...item } : item);
+    }
     return Array.from(map.values());
   };
 

--- a/tests/mergeBoards.spec.ts
+++ b/tests/mergeBoards.spec.ts
@@ -49,4 +49,30 @@ describe('mergeBoards', () => {
     const merged = mergeBoards(remote, local);
     expect(merged.incoming).toHaveLength(2);
   });
+
+  it('keeps remote metadata when incoming entries collide', () => {
+    const remote = {
+      ...base(),
+      incoming: [{ nurseId: 'n1', eta: '1', arrived: true }],
+    };
+    const local = {
+      ...base(),
+      incoming: [{ nurseId: 'n1', eta: '1', arrived: false }],
+    };
+    const merged = mergeBoards(remote, local);
+    expect(merged.incoming[0].arrived).toBe(true);
+  });
+
+  it('keeps remote metadata when offgoing entries collide', () => {
+    const remote = {
+      ...base(),
+      offgoing: [{ nurseId: 'n1', ts: 1, note: 'server' } as any],
+    };
+    const local = {
+      ...base(),
+      offgoing: [{ nurseId: 'n1', ts: 1, note: 'client' } as any],
+    };
+    const merged = mergeBoards(remote, local);
+    expect((merged.offgoing[0] as any).note).toBe('server');
+  });
 });


### PR DESCRIPTION
## Summary
- avoid overwriting fresh server data when merging boards
- add regression tests for incoming/offgoing metadata preservation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba433aeb7c83279859b51005c8ab39