### PR TITLE
fix: preserve remote order when merging arrays

### DIFF
--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -152,13 +152,14 @@ export function mergeBoards(remote: ActiveBoard, local: ActiveBoard): ActiveBoar
     key: (item: T) => string
   ): T[] => {
     const map = new Map<string, T>();
-    for (const item of b) {
+    // Insert remote items first so their order is preserved when merging.
+    for (const item of a) {
       map.set(key(item), item);
     }
-    for (const item of a) {
+    for (const item of b) {
       const k = key(item);
       const existing = map.get(k);
-      map.set(k, existing ? { ...existing, ...item } : item);
+      map.set(k, existing ? { ...item, ...existing } : item);
     }
     return Array.from(map.values());
   };

--- a/tests/mergeBoards.spec.ts
+++ b/tests/mergeBoards.spec.ts
@@ -75,4 +75,23 @@ describe('mergeBoards', () => {
     const merged = mergeBoards(remote, local);
     expect((merged.offgoing[0] as any).note).toBe('server');
   });
+
+  it('preserves remote ordering when arrays collide', () => {
+    const remote = {
+      ...base(),
+      incoming: [
+        { nurseId: 'n1', eta: '1' },
+        { nurseId: 'n2', eta: '2' },
+      ],
+    };
+    const local = {
+      ...base(),
+      incoming: [
+        { nurseId: 'n2', eta: '2' },
+        { nurseId: 'n1', eta: '1' },
+      ],
+    };
+    const merged = mergeBoards(remote, local);
+    expect(merged.incoming.map((i) => i.nurseId)).toEqual(['n1', 'n2']);
+  });
 });


### PR DESCRIPTION
## Summary
- keep remote ordering when merging arrays
- test that remote order wins over local stale order

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bae49c399c8327818ce2c3ad59c095