### PR TITLE
Fix Meteomatics timestamp generation

### DIFF
--- a/src/weather/meteomatics.ts
+++ b/src/weather/meteomatics.ts
@@ -15,7 +15,8 @@ function toLocalISO(dt: Date) {
   const sign = tzOffMin >= 0 ? '+' : '-';
   const hh = pad2(Math.floor(Math.abs(tzOffMin) / 60));
   const mm = pad2(Math.abs(tzOffMin) % 60);
-  return dt.toISOString().slice(0,19) + `${sign}${hh}:${mm}`;
+  const local = new Date(dt.getTime() - dt.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 19) + `${sign}${hh}:${mm}`;
 }
 
 export function buildTimeWindow(hoursBack: number, hoursFwd: number) {

--- a/tests/meteomatics.spec.ts
+++ b/tests/meteomatics.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildTimeWindow } from '@/weather/meteomatics';
+
+describe('buildTimeWindow', () => {
+  it('formats times in local time with offset', () => {
+    vi.useFakeTimers();
+    const base = new Date('2023-09-04T14:30:00Z');
+    vi.setSystemTime(base);
+    const spy = vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(240);
+    const { startISO, endISO } = buildTimeWindow(0, 0);
+    spy.mockRestore();
+    vi.useRealTimers();
+    expect(startISO).toBe('2023-09-04T10:00:00-04:00');
+    expect(endISO).toBe('2023-09-04T10:00:00-04:00');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure Meteomatics timestamps use local time before adding offset
- add unit test covering timestamp formatting

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bae567f06c8327b7e2baa5e54fc474