### PR TITLE
Prevent hidden assignments and handle Next Shift load errors

### DIFF
--- a/src/state/nextShift.ts
+++ b/src/state/nextShift.ts
@@ -31,8 +31,13 @@ export function buildEmptyDraft(
 
 /** Load the current next-shift draft from the server. */
 export async function loadNextDraft(): Promise<DraftShift | null> {
-  const raw = await Server.load('next');
-  return raw && Object.keys(raw).length ? (raw as DraftShift) : null;
+  try {
+    const raw = await Server.load('next');
+    return raw && Object.keys(raw).length ? (raw as DraftShift) : null;
+  } catch (err) {
+    console.warn('loadNextDraft failed', err);
+    return null;
+  }
 }
 
 /** Persist a next-shift draft to the server. */

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -384,10 +384,15 @@ function renderZones(
     body.className = 'zone-card__body';
 
     (active.zones[zName] || []).forEach((s: Slot, idx: number) => {
-      const st = staff.find((n) => n.id === s.nurseId);
+      let st = staff.find((n) => n.id === s.nurseId);
       if (!st) {
         console.warn('Unknown staffId', s.nurseId);
-        return;
+        st = {
+          id: s.nurseId,
+          name: s.nurseId,
+          role: 'nurse',
+          type: 'other',
+        } as Staff;
       }
 
       const row = document.createElement('div');


### PR DESCRIPTION
## Summary
- Render placeholder tiles when a zone references unknown staff so assignments remain visible
- Return an empty draft when fetching the next-shift data fails to prevent blank Next Shift tab

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bae88cd4c0832788ba4bdea07b360e