### PR TITLE
Use proxy for physician calendar to avoid CORS

### DIFF
--- a/tests/physicians.spec.ts
+++ b/tests/physicians.spec.ts
@@ -124,7 +124,7 @@ describe('physician schedule parsing', () => {
       'END:VCALENDAR',
     ].join('\n');
 
-    // Mock first fetch attempt (direct URL) to succeed and return sample ICS
+    // Mock proxy fetch to return sample ICS
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       text: () => Promise.resolve(sample),
@@ -138,8 +138,11 @@ describe('physician schedule parsing', () => {
       '2024-01-05': ['Dr C'],
     });
 
-    // Ensure we used the direct fetch at least once
-    expect(fetchMock).toHaveBeenCalled();
+    // Ensure we hit the proxy endpoint
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api.php?action=physicians',
+      { credentials: 'same-origin' }
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Use local PHP endpoint to fetch physician calendar when calendar URL is cross-origin
- Update tests for proxy-based physician calendar fetch

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68baec1f82848327943905a38f6c1925