### PR TITLE
Ensure theme settings persist across refresh

### DIFF
--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -1,4 +1,4 @@
-import { getConfig, saveConfig } from './config';
+import { getConfig, saveConfig } from '.';
 
 export type UIMode = 'system' | 'light' | 'dark';
 


### PR DESCRIPTION
## Summary
- Use shared app configuration for theme state so saved light/dark mode settings persist after a refresh

## Testing
- `npm test` *(fails: buildTimeWindow is not a function)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68baee1369dc83278460822bae33fcb6