### PR TITLE
feat: add next shift planning UI

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -10,7 +10,7 @@ Below the header, tabs switch between major views: **Board**, **Next Shift**, **
 The Board presents the live staffing picture. The left column contains panels for the patient care team, nurse assignments, and a comments box【F:src/ui/board.ts†L82-L101】. The right column offers weather information, incoming patients with an add button, recently offgoing staff, and a read‑only physician schedule【F:src/ui/board.ts†L104-L124】
 
 ## Next Shift Tab
-The Next Shift tab is used to prepare upcoming shifts. It currently provides placeholder controls for saving a draft and publishing it to the main board【F:src/ui/nextShift/NextShiftPage.ts†L1-L36】
+The Next Shift tab is used to prepare upcoming shifts. It offers fields to choose the date and shift, assign nurses to leadership roles and zones, and buttons to save the draft or publish it to the main board【F:src/ui/nextShift/NextShiftPage.ts†L1-L121】
 
 ## Settings Tab
 Settings combines roster management and display options. It includes a roster pane, areas for editing nurse details, general settings, display settings, and separate sections for widgets and a nurse type legend【F:src/ui/settings.ts†L31-L41】

--- a/src/ui/nextShift/NextShiftPage.ts
+++ b/src/ui/nextShift/NextShiftPage.ts
@@ -1,20 +1,93 @@
 import './nextShift.css';
 import { getConfig } from '@/state/config';
-import { buildEmptyDraft, loadNextDraft, saveNextDraft, publishNextDraft, type DraftShift } from '@/state/nextShift';
+import {
+  buildEmptyDraft,
+  loadNextDraft,
+  saveNextDraft,
+  publishNextDraft,
+  type DraftShift,
+} from '@/state/nextShift';
+import { loadStaff, type Staff } from '@/state/staff';
+import { type Slot } from '@/slots';
 import { toDateISO } from '@/utils/time';
+
+function staffOptions(staff: Staff[], selected?: string): string {
+  return (
+    '<option value=""></option>' +
+    staff
+      .map(
+        (s) =>
+          `<option value="${s.id}" ${s.id === selected ? 'selected' : ''}>${
+            s.name || s.id
+          }</option>`
+      )
+      .join('')
+  );
+}
+
+function buildSelect(id: string, staff: Staff[], selected?: string): string {
+  return `<select id="${id}">${staffOptions(staff, selected)}</select>`;
+}
+
+function readSlot(id: string): Slot | undefined {
+  const el = document.getElementById(id) as HTMLSelectElement | null;
+  return el && el.value ? { nurseId: el.value } : undefined;
+}
 
 /** Render a simple Next Shift planning page with save and publish controls. */
 export async function renderNextShiftPage(root: HTMLElement): Promise<void> {
   const cfg = getConfig();
+  const staff = await loadStaff();
   let draft: DraftShift | null = await loadNextDraft();
   if (!draft) {
     const tomorrow = toDateISO(new Date(Date.now() + 24 * 60 * 60 * 1000));
     draft = buildEmptyDraft(tomorrow, 'day', cfg.zones || []);
   }
 
+  const zoneRows = (cfg.zones || [])
+    .map((z) => {
+      const slot = draft?.zones?.[z.name]?.[0];
+      return `<tr><td>${z.name}</td><td>${buildSelect(
+        `zone-${z.id}`,
+        staff,
+        slot?.nurseId
+      )}</td></tr>`;
+    })
+    .join('');
+
   root.innerHTML = `
     <section class="panel next-shift" data-testid="next-shift">
       <h3>Next Shift</h3>
+      <div class="fields">
+        <label>Date <input type="date" id="next-date" value="${
+          draft.dateISO
+        }"></label>
+        <label>Shift <select id="next-shift-select">
+          <option value="day" ${draft.shift === 'day' ? 'selected' : ''}>Day</option>
+          <option value="night" ${draft.shift === 'night' ? 'selected' : ''}>Night</option>
+        </select></label>
+      </div>
+      <table class="assignments">
+        <thead><tr><th>Role/Zone</th><th>Nurse</th></tr></thead>
+        <tbody>
+          <tr><td>Charge</td><td>${buildSelect(
+            'charge',
+            staff,
+            draft.charge?.nurseId
+          )}</td></tr>
+          <tr><td>Triage</td><td>${buildSelect(
+            'triage',
+            staff,
+            draft.triage?.nurseId
+          )}</td></tr>
+          <tr><td>Secretary</td><td>${buildSelect(
+            'admin',
+            staff,
+            draft.admin?.nurseId
+          )}</td></tr>
+          ${zoneRows}
+        </tbody>
+      </table>
       <div class="actions">
         <button id="next-save" class="btn">Save Draft</button>
         <button id="next-publish" class="btn">Publish</button>
@@ -22,15 +95,42 @@ export async function renderNextShiftPage(root: HTMLElement): Promise<void> {
     </section>
   `;
 
-  document.getElementById('next-save')?.addEventListener('click', async () => {
-    if (draft) await saveNextDraft(draft);
-  });
-  document.getElementById('next-publish')?.addEventListener('click', async () => {
-    if (draft) await saveNextDraft(draft);
-    try {
-      await publishNextDraft({ appendHistory: true });
-    } catch (err) {
-      console.error(err);
+  function gatherDraft(): DraftShift {
+    const dateISO = (document.getElementById('next-date') as HTMLInputElement)
+      .value;
+    const shift = (document.getElementById(
+      'next-shift-select'
+    ) as HTMLSelectElement).value as 'day' | 'night';
+    const zones: Record<string, Slot[]> = {};
+    for (const z of cfg.zones || []) {
+      const slot = readSlot(`zone-${z.id}`);
+      zones[z.name] = slot ? [slot] : [];
     }
+    return {
+      ...draft!,
+      dateISO,
+      shift,
+      charge: readSlot('charge'),
+      triage: readSlot('triage'),
+      admin: readSlot('admin'),
+      zones,
+    };
+  }
+
+  document.getElementById('next-save')?.addEventListener('click', async () => {
+    draft = gatherDraft();
+    await saveNextDraft(draft);
   });
+
+  document
+    .getElementById('next-publish')
+    ?.addEventListener('click', async () => {
+      draft = gatherDraft();
+      await saveNextDraft(draft);
+      try {
+        await publishNextDraft({ appendHistory: true });
+      } catch (err) {
+        console.error(err);
+      }
+    });
 }

--- a/src/ui/nextShift/__tests__/NextShiftPage.test.ts
+++ b/src/ui/nextShift/__tests__/NextShiftPage.test.ts
@@ -1,0 +1,48 @@
+/** @vitest-environment happy-dom */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderNextShiftPage } from '../NextShiftPage';
+
+vi.mock('@/state/config', () => ({
+  getConfig: () => ({ zones: [{ id: 'a', name: 'A' }] }),
+}));
+
+vi.mock('@/state/nextShift', () => ({
+  buildEmptyDraft: (dateISO: string, shift: 'day' | 'night', zones: any[]) => ({
+    dateISO,
+    shift,
+    charge: undefined,
+    triage: undefined,
+    admin: undefined,
+    zones: Object.fromEntries(zones.map((z: any) => [z.name, []])),
+    incoming: [],
+    offgoing: [],
+    huddle: '',
+    handoff: '',
+    version: 2,
+  }),
+  loadNextDraft: vi.fn().mockResolvedValue(null),
+  saveNextDraft: vi.fn(),
+  publishNextDraft: vi.fn(),
+}));
+
+vi.mock('@/state/staff', () => ({
+  loadStaff: vi.fn().mockResolvedValue([{ id: 'n1', name: 'Alice' }]),
+}));
+
+describe('renderNextShiftPage', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="root"></div>';
+  });
+
+  it('renders zone select and saves draft', async () => {
+    const root = document.getElementById('root') as HTMLElement;
+    await renderNextShiftPage(root);
+    const zoneSel = root.querySelector('select#zone-a') as HTMLSelectElement;
+    expect(zoneSel).toBeTruthy();
+    zoneSel.value = 'n1';
+    (root.querySelector('#next-save') as HTMLButtonElement).click();
+    await Promise.resolve();
+    const { saveNextDraft } = await import('@/state/nextShift');
+    expect((saveNextDraft as any).mock.calls[0][0].zones['A'][0].nurseId).toBe('n1');
+  });
+});

--- a/src/ui/nextShift/nextShift.css
+++ b/src/ui/nextShift/nextShift.css
@@ -3,7 +3,21 @@
   flex-direction: column;
   gap: var(--gap);
 }
+.next-shift .fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap);
+}
 .next-shift .actions {
   display: flex;
   gap: var(--gap);
+}
+.next-shift table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.next-shift th,
+.next-shift td {
+  padding: 0.25rem;
+  text-align: left;
 }


### PR DESCRIPTION
## Summary
- add basic Next Shift planning interface with nurse assignments
- style next shift table
- document new Next Shift features

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68baf1f388348327a9fd3cda9228754a