### PR TITLE
Fix history-saved toast trigger

### DIFF
--- a/src/state/board.ts
+++ b/src/state/board.ts
@@ -3,7 +3,6 @@ import * as DB from '@/db';
 import { savePublishedShift, indexStaffAssignments, getHuddle, type ShiftKind, type PublishedShiftSnapshot, type Assignment } from '@/state/history';
 import { loadStaff, type Staff } from './staff';
 import { KS } from './keys';
-import { showToast } from '@/ui/banner';
 
 import type { Slot } from '@/slots';
 export type { Slot } from '@/slots';
@@ -224,7 +223,6 @@ export async function applyDraftToActive(
   await indexStaffAssignments(snapshot);
   if (typeof document !== 'undefined') {
     document.dispatchEvent(new Event('history-saved'));
-    showToast('assignments saved to history');
   }
 }
 

--- a/src/state/history.ts
+++ b/src/state/history.ts
@@ -220,6 +220,9 @@ export async function submitHuddle(record: HuddleRecord): Promise<void> {
   const base = HUDDLE_KEY(record.dateISO, record.shift);
   await kvSet(`${base}:${record.recordedAtISO}`, record);
   await kvDel(base);
+  if (typeof document !== 'undefined') {
+    document.dispatchEvent(new Event('history-saved'));
+  }
 }
 
 /** Clone and replace an existing snapshot with audit trail update. */

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -542,6 +542,10 @@ export async function applyDraftToActive(
   };
   await savePublishedShift(snapshot);
   await indexStaffAssignments(snapshot);
+
+  if (typeof document !== 'undefined') {
+    document.dispatchEvent(new Event('history-saved'));
+  }
 }
 
 export { DB };


### PR DESCRIPTION
## Summary
- dispatch history-saved events when saving a huddle or publishing a shift so UI toasts appear
- centralize event handling by removing direct toast call in board state

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68baf28afd7083278f48eeef3707f410