### PR TITLE
feat: wrap staff history in container

### DIFF
--- a/src/history/NurseHistory.ts
+++ b/src/history/NurseHistory.ts
@@ -16,10 +16,12 @@ export function renderNurseHistory(root: HTMLElement): void {
         <button id="hist-nurse-load" class="btn">Load</button>
         <button id="hist-nurse-export" class="btn">Export CSV</button>
       </div>
-      <table class="history-table">
-        <thead><tr><th>Date</th><th>Shift</th><th>Zone</th><th>Prev Zone</th></tr></thead>
-        <tbody id="hist-nurse-body"><tr><td colspan="4">Select a nurse</td></tr></tbody>
-      </table>
+      <div class="history-box">
+        <table class="history-table">
+          <thead><tr><th>Date</th><th>Shift</th><th>Zone</th><th>Prev Zone</th></tr></thead>
+          <tbody id="hist-nurse-body"><tr><td colspan="4">Select a nurse</td></tr></tbody>
+        </table>
+      </div>
     </div>
   `;
 

--- a/src/history/history.css
+++ b/src/history/history.css
@@ -3,3 +3,4 @@
 .history-table{border-collapse:collapse;width:100%}
 .history-table th,.history-table td{border:1px solid #ccc;padding:4px;text-align:left}
 .history-table thead{background:#f5f5f5}
+.history-box{border:1px solid var(--card-border,#ccc);padding:8px;border-radius:4px;margin-top:8px}

--- a/src/styles.css
+++ b/src/styles.css
@@ -227,6 +227,7 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .assign-item{padding:4px 8px;cursor:pointer;}
 .assign-item:hover{background:var(--control);}
 .assign-details{font-size:.9em;margin-top:8px;min-height:1.2em;}
+.history-box{border:1px solid var(--card-border);padding:8px;border-radius:4px;margin-top:8px}
 .banner{background:var(--danger);color:var(--text);padding:8px;text-align:center}
 .toast{position:fixed;top:16px;right:16px;background:rgba(0,0,0,.6);color:var(--text);padding:8px 12px;border-radius:8px;z-index:var(--z-modal)}
 

--- a/src/ui/assignDialog.ts
+++ b/src/ui/assignDialog.ts
@@ -75,12 +75,19 @@ export function openAssignDialog(
     confirm.disabled = false;
     const history = await findShiftsByStaff(id);
     const recent = history.slice(0, 5);
-    details.innerHTML = recent
-      .map(
-        (h) =>
-          `${h.dateISO} ${h.shift} - ${h.zone}${h.dto ? ' (DTO)' : ''}`
-      )
-      .join('<br>') || 'No recent shifts';
+    details.innerHTML = `
+      <div class="history-box">
+        ${
+          recent.length
+            ? `<ul>${recent
+                .map(
+                  (h) =>
+                    `<li>${h.dateISO} ${h.shift} - ${h.zone}${h.dto ? ' (DTO)' : ''}</li>`
+                )
+                .join('')}</ul>`
+            : 'No recent shifts'
+        }
+      </div>`;
   };
 
   searchInput.addEventListener('input', () => render(searchInput.value));


### PR DESCRIPTION
## Summary
- highlight recent shifts in assign dialog using a bordered container
- show nurse history search results in same styled container
- add shared `history-box` styles

## Testing
- `npm test` *(passes: 31 passed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68baf2e70d408327b603081d3ea27f2b