### PR TITLE
feat: sync history with server and migrate local data

### DIFF
--- a/server/api.php
+++ b/server/api.php
@@ -132,6 +132,32 @@ try {
       ok(['ok' => true]);
     }
 
+    case 'historyKv': {
+      $mode = $_GET['mode'] ?? '';
+      $k = $_GET['key'] ?? '';
+      if ($k === '' || strncmp($k, 'history:', 8) !== 0) bad('invalid key');
+
+      if ($mode === 'get') {
+        $data = kvGet($k, null);
+        ok($data);
+      }
+
+      if ($mode === 'set') {
+        $raw = file_get_contents('php://input') ?: 'null';
+        $data = json_decode($raw, true);
+        if (json_last_error() !== JSON_ERROR_NONE) bad('invalid json');
+        kvSet($k, $data);
+        ok(['ok' => true]);
+      }
+
+      if ($mode === 'del') {
+        db()->prepare('DELETE FROM kv_store WHERE key = :k')->execute([':k' => $k]);
+        ok(['ok' => true]);
+      }
+
+      bad('invalid mode');
+    }
+
     case 'history': {
       $params = validateHistoryQuery($_GET); // expects mode + (date|nurseId)
       $hist = historyAll(); // array of published shift snapshots


### PR DESCRIPTION
## Summary
- sync history state with server through new historyKv endpoints
- migrate any existing local history into server storage on load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bafd0e44988327ba952ebcc6069d59