### PR TITLE
feat: persist shifts via server

### DIFF
--- a/api.php
+++ b/api.php
@@ -42,7 +42,7 @@ function bad(string $msg, int $code = 400): void {
 /** Allow only known keys to map to files in /data */
 function normalizeKey(string $key): string {
   $key = basename($key);
-  $allowed = ['roster', 'config', 'active', 'next'];
+  $allowed = ['roster', 'config', 'active', 'next', 'shifts', 'handoff'];
   if (!in_array($key, $allowed, true)) bad('invalid key');
   return $key;
 }
@@ -81,6 +81,8 @@ switch ($action) {
       'config' => new stdClass(),
       'active' => new stdClass(),
       'next' => new stdClass(),
+      'shifts' => [],
+      'handoff' => new stdClass(),
     ];
     echo json_encode(safeReadJson($path, $defaults[$key] ?? new stdClass()), JSON_UNESCAPED_UNICODE);
     exit;

--- a/server/api.php
+++ b/server/api.php
@@ -47,7 +47,7 @@ function ok($payload = null): void {
 }
 function normalizeKey(string $key): string {
   $key = basename($key);
-  $allowed = ['roster','config','active'];
+  $allowed = ['roster','config','active','shifts','handoff'];
   if (!in_array($key, $allowed, true)) bad('invalid key');
   return $key;
 }
@@ -100,6 +100,8 @@ try {
         $defaults = [
           'roster' => [],
           'config' => new stdClass(),
+          'shifts' => [],
+          'handoff' => new stdClass(),
         ];
         $data = kvGet($key, $defaults[$key] ?? new stdClass());
       }

--- a/src/types/shifts.ts
+++ b/src/types/shifts.ts
@@ -1,3 +1,5 @@
+import * as Server from '@/server';
+
 export type ShiftId = string;
 
 export type ShiftStatus = 'draft' | 'onbat' | 'live' | 'overlap' | 'archived';
@@ -31,39 +33,38 @@ export type Handoff = {
   status: 'draft' | 'inPerson' | 'readyToCreate' | 'overlap' | 'done';
 };
 
-const SHIFTS_KEY = 'sb_shifts_v1';
-const HANDOFF_KEY = 'sb_handoff_v1';
-
-export function loadShifts(): Shift[] {
+/** Load all draft shifts from the server. */
+export async function loadShifts(): Promise<Shift[]> {
   try {
-    const raw = localStorage.getItem(SHIFTS_KEY);
-    return raw ? (JSON.parse(raw) as Shift[]) : [];
+    return (await Server.load('shifts')) as Shift[];
   } catch {
     return [];
   }
 }
 
-export function saveShifts(list: Shift[]): void {
+/** Persist draft shifts to the server. */
+export async function saveShifts(list: Shift[]): Promise<void> {
   try {
-    localStorage.setItem(SHIFTS_KEY, JSON.stringify(list));
+    await Server.save('shifts', list);
   } catch {
     /* ignore */
   }
 }
 
-export function loadActiveHandoff(): Handoff | undefined {
+/** Load the active handoff record from the server. */
+export async function loadActiveHandoff(): Promise<Handoff | undefined> {
   try {
-    const raw = localStorage.getItem(HANDOFF_KEY);
-    return raw ? (JSON.parse(raw) as Handoff) : undefined;
+    const data = await Server.load('handoff');
+    return data && Object.keys(data).length ? (data as Handoff) : undefined;
   } catch {
     return undefined;
   }
 }
 
-export function saveActiveHandoff(h: Handoff | undefined): void {
+/** Save the active handoff record to the server. */
+export async function saveActiveHandoff(h: Handoff | undefined): Promise<void> {
   try {
-    if (h) localStorage.setItem(HANDOFF_KEY, JSON.stringify(h));
-    else localStorage.removeItem(HANDOFF_KEY);
+    await Server.save('handoff', h || {});
   } catch {
     /* ignore */
   }


### PR DESCRIPTION
## Summary
- replace localStorage-based shift and handoff helpers with server-backed versions
- update handoff state logic to use async server persistence
- extend PHP API to load/save shift and handoff data in database

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bafd0a5abc832781312b73ef837834