### PR TITLE
Add staff search panel to Next Shift page

### DIFF
--- a/src/ui/nextShift/NextShiftPage.ts
+++ b/src/ui/nextShift/NextShiftPage.ts
@@ -58,42 +58,100 @@ export async function renderNextShiftPage(root: HTMLElement): Promise<void> {
   root.innerHTML = `
     <section class="panel next-shift" data-testid="next-shift">
       <h3>Next Shift</h3>
-      <div class="fields">
-        <label>Date <input type="date" id="next-date" value="${
-          draft.dateISO
-        }"></label>
-        <label>Shift <select id="next-shift-select">
-          <option value="day" ${draft.shift === 'day' ? 'selected' : ''}>Day</option>
-          <option value="night" ${draft.shift === 'night' ? 'selected' : ''}>Night</option>
-        </select></label>
-      </div>
-      <table class="assignments">
-        <thead><tr><th>Role/Zone</th><th>Nurse</th></tr></thead>
-        <tbody>
-          <tr><td>Charge</td><td>${buildSelect(
-            'charge',
-            staff,
-            draft.charge?.nurseId
-          )}</td></tr>
-          <tr><td>Triage</td><td>${buildSelect(
-            'triage',
-            staff,
-            draft.triage?.nurseId
-          )}</td></tr>
-          <tr><td>Secretary</td><td>${buildSelect(
-            'admin',
-            staff,
-            draft.admin?.nurseId
-          )}</td></tr>
-          ${zoneRows}
-        </tbody>
-      </table>
-      <div class="actions">
-        <button id="next-save" class="btn">Save Draft</button>
-        <button id="next-publish" class="btn">Publish</button>
+      <div class="next-shift-body">
+        <div class="staff-panel">
+          <input id="next-search" class="input" placeholder="Search staff">
+          <div class="assign-cols">
+            <div id="next-nurses" class="assign-col"></div>
+            <div id="next-techs" class="assign-col"></div>
+          </div>
+        </div>
+        <div class="assign-panel">
+          <div class="fields">
+            <label>Date <input type="date" id="next-date" value="${
+              draft.dateISO
+            }"></label>
+            <label>Shift <select id="next-shift-select">
+              <option value="day" ${draft.shift === 'day' ? 'selected' : ''}>Day</option>
+              <option value="night" ${draft.shift === 'night' ? 'selected' : ''}>Night</option>
+            </select></label>
+          </div>
+          <table class="assignments">
+            <thead><tr><th>Role/Zone</th><th>Nurse</th></tr></thead>
+            <tbody>
+              <tr><td>Charge</td><td>${buildSelect(
+                'charge',
+                staff,
+                draft.charge?.nurseId
+              )}</td></tr>
+              <tr><td>Triage</td><td>${buildSelect(
+                'triage',
+                staff,
+                draft.triage?.nurseId
+              )}</td></tr>
+              <tr><td>Secretary</td><td>${buildSelect(
+                'admin',
+                staff,
+                draft.admin?.nurseId
+              )}</td></tr>
+              ${zoneRows}
+            </tbody>
+          </table>
+          <div class="actions">
+            <button id="next-save" class="btn">Save Draft</button>
+            <button id="next-publish" class="btn">Publish</button>
+          </div>
+        </div>
       </div>
     </section>
   `;
+
+  const nurseCol = document.getElementById('next-nurses') as HTMLElement;
+  const techCol = document.getElementById('next-techs') as HTMLElement;
+  const searchInput = document.getElementById('next-search') as HTMLInputElement;
+
+  let activeSelect: HTMLSelectElement | null = null;
+
+  function renderStaff(filter = ''): void {
+    const norm = filter.toLowerCase();
+    const nurses = staff.filter(
+      (s) =>
+        s.role === 'nurse' &&
+        (!filter || (s.name || s.id).toLowerCase().includes(norm))
+    );
+    const techs = staff.filter(
+      (s) =>
+        s.role === 'tech' &&
+        (!filter || (s.name || s.id).toLowerCase().includes(norm))
+    );
+    nurseCol.innerHTML = nurses
+      .map(
+        (s) => `<div class="assign-item" data-id="${s.id}">${s.name || s.id}</div>`
+      )
+      .join('');
+    techCol.innerHTML = techs
+      .map(
+        (s) => `<div class="assign-item" data-id="${s.id}">${s.name || s.id}</div>`
+      )
+      .join('');
+    document.querySelectorAll('.assign-item').forEach((el) => {
+      const id = (el as HTMLElement).dataset.id!;
+      el.addEventListener('click', () => {
+        if (activeSelect) {
+          activeSelect.value = id;
+        }
+      });
+    });
+  }
+
+  renderStaff();
+  searchInput.addEventListener('input', () => renderStaff(searchInput.value));
+
+  root.querySelectorAll('select').forEach((sel) => {
+    sel.addEventListener('focus', () => {
+      activeSelect = sel as HTMLSelectElement;
+    });
+  });
 
   function gatherDraft(): DraftShift {
     const dateISO = (document.getElementById('next-date') as HTMLInputElement)

--- a/src/ui/nextShift/__tests__/NextShiftPage.test.ts
+++ b/src/ui/nextShift/__tests__/NextShiftPage.test.ts
@@ -26,7 +26,7 @@ vi.mock('@/state/nextShift', () => ({
 }));
 
 vi.mock('@/state/staff', () => ({
-  loadStaff: vi.fn().mockResolvedValue([{ id: 'n1', name: 'Alice' }]),
+  loadStaff: vi.fn().mockResolvedValue([{ id: 'n1', name: 'Alice', role: 'nurse' }]),
 }));
 
 describe('renderNextShiftPage', () => {
@@ -44,5 +44,18 @@ describe('renderNextShiftPage', () => {
     await Promise.resolve();
     const { saveNextDraft } = await import('@/state/nextShift');
     expect((saveNextDraft as any).mock.calls[0][0].zones['A'][0].nurseId).toBe('n1');
+  });
+
+  it('filters staff and assigns to focused select', async () => {
+    const root = document.getElementById('root') as HTMLElement;
+    await renderNextShiftPage(root);
+    const search = root.querySelector('#next-search') as HTMLInputElement;
+    search.value = 'ali';
+    search.dispatchEvent(new Event('input'));
+    const zoneSel = root.querySelector('select#zone-a') as HTMLSelectElement;
+    zoneSel.focus();
+    const item = root.querySelector('.assign-item[data-id="n1"]') as HTMLElement;
+    item.click();
+    expect(zoneSel.value).toBe('n1');
   });
 });

--- a/src/ui/nextShift/nextShift.css
+++ b/src/ui/nextShift/nextShift.css
@@ -3,6 +3,22 @@
   flex-direction: column;
   gap: var(--gap);
 }
+.next-shift-body {
+  display: flex;
+  gap: var(--gap);
+}
+.next-shift .staff-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
+}
+.next-shift .assign-panel {
+  flex: 2;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
+}
 .next-shift .fields {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- show searchable two-column staff list on Next Shift view
- allow clicking staff to fill focused zone select
- cover interactions with tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68baff1e6494832789e9b3b25f2f38be