### PR TITLE
Simplify next shift planning UI

### DIFF
--- a/src/ui/nextShift/__tests__/NextShiftPage.test.ts
+++ b/src/ui/nextShift/__tests__/NextShiftPage.test.ts
@@ -50,8 +50,11 @@ describe('renderNextShiftPage', () => {
     await Promise.resolve();
 
     const { saveNextDraft } = await import('@/state/nextShift');
-    expect((saveNextDraft as any).mock.calls[0][0].zones['A'][0].nurseId).toBe('n1');
-    expect((saveNextDraft as any).mock.calls[0][0].publishAtISO).toBe('2024-01-01T07:00');
+    const saved = (saveNextDraft as any).mock.calls[0][0];
+    expect(saved.zones['A'][0].nurseId).toBe('n1');
+    expect(saved.publishAtISO).toBe('2024-01-01T07:00');
+    expect(saved.dateISO).toBe('2024-01-01');
+    expect(saved.shift).toBe('day');
   });
 
   it('publishes draft (no history append expected here)', async () => {

--- a/src/ui/nextShift/nextShift.css
+++ b/src/ui/nextShift/nextShift.css
@@ -19,11 +19,6 @@
   flex-direction: column;
   gap: var(--gap);
 }
-.next-shift .fields {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--gap);
-}
 .next-shift .actions {
   display: flex;
   gap: var(--gap);


### PR DESCRIPTION
## Summary
- remove shift and date selectors from Next Shift draft
- derive draft shift automatically from Go Live time
- support dragging staff into zone assignments

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb07555b708327a6a7b3fea25c91e5