### PR TITLE
Add historyKv API endpoint and normalize end-time overrides

### DIFF
--- a/api.php
+++ b/api.php
@@ -121,6 +121,35 @@ switch ($action) {
     exit;
   }
 
+  case 'historyKv': {
+    $mode = $_GET['mode'] ?? '';
+    $k = $_GET['key'] ?? '';
+    if ($k === '' || strncmp($k, 'history:', 8) !== 0) bad('invalid key');
+    $kvDir = "$DATA_DIR/kv";
+    if (!is_dir($kvDir)) @mkdir($kvDir, 0775, true);
+    $path = $kvDir . '/' . basename($k) . '.json';
+
+    if ($mode === 'get') {
+      $data = safeReadJson($path, null);
+      echo json_encode($data, JSON_UNESCAPED_UNICODE); exit;
+    }
+
+    if ($mode === 'set') {
+      $raw = file_get_contents('php://input');
+      $data = json_decode($raw, true);
+      if ($raw !== '' && json_last_error() !== JSON_ERROR_NONE) bad('invalid JSON');
+      safeWriteJson($path, $data);
+      echo json_encode(['ok' => true], JSON_UNESCAPED_UNICODE); exit;
+    }
+
+    if ($mode === 'del') {
+      @unlink($path);
+      echo json_encode(['ok' => true], JSON_UNESCAPED_UNICODE); exit;
+    }
+
+    bad('invalid mode');
+  }
+
   case 'history': {
     $mode = $_GET['mode'] ?? '';
     $hist = safeReadJson($historyPath, []);

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -332,7 +332,10 @@ function renderZones(
       const dt = (e as DragEvent).dataTransfer;
       const nurseId = dt?.getData('incoming-id');
       if (nurseId) {
-        const end = prompt('Shift end time (HH:MM)?')?.trim();
+        const rawEnd = prompt('Shift end time (HH:MM)?')?.trim();
+        const end = rawEnd && /^\d{4}$/.test(rawEnd)
+          ? rawEnd.replace(/(\d{2})(\d{2})/, '$1:$2')
+          : rawEnd;
         const slot: Slot = { nurseId, startHHMM: STATE.clockHHMM };
         if (end) slot.endTimeOverrideHHMM = end;
         const moved = upsertSlot(active, { zone: z.name }, slot);
@@ -652,6 +655,9 @@ function manageSlot(
   if (!st) return;
 
   const currentRole = st.role;
+  const endValue = slot.endTimeOverrideHHMM && /^\d{4}$/.test(slot.endTimeOverrideHHMM)
+    ? slot.endTimeOverrideHHMM.replace(/(\d{2})(\d{2})/, '$1:$2')
+    : (slot.endTimeOverrideHHMM || '');
 
   const overlay = document.createElement('div');
   overlay.className = 'manage-overlay';
@@ -678,7 +684,7 @@ function manageSlot(
       <label>Comment <input id="mg-comment" value="${slot.comment || ''}"></label>
       <label><input type="checkbox" id="mg-break" ${slot.break?.active ? 'checked' : ''}/> On break</label>
       <label><input type="checkbox" id="mg-bad" ${slot.bad ? 'checked' : ''}/> Bad</label>
-      <label>End time <input id="mg-end" type="time" value="${slot.endTimeOverrideHHMM || ''}"></label>
+      <label>End time <input id="mg-end" type="time" value="${endValue}"></label>
       <label>Zone <select id="mg-zone">
         ${(cfg.zones || [])
           .map((z: ZoneDef) => `<option value="${z.name}"${z.name === zone ? ' selected' : ''}>${z.name}</option>`)


### PR DESCRIPTION
## Summary
- normalize end-time overrides to HH:mm format before saving or editing
- support `historyKv` in the PHP API using JSON files for storage

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb0815f8f48327b8d8732c5963ab4d