### PR TITLE
Seed default zones for Next Shift page

### DIFF
--- a/src/ui/nextShift/NextShiftPage.ts
+++ b/src/ui/nextShift/NextShiftPage.ts
@@ -1,5 +1,6 @@
 import './nextShift.css';
 import { getConfig } from '@/state/config';
+import { seedZonesIfNeeded } from '@/seed';
 import {
   buildEmptyDraft,
   loadNextDraft,
@@ -36,6 +37,7 @@ function readSlot(id: string): Slot | undefined {
 
 /** Render a simple Next Shift planning page with save and publish controls. */
 export async function renderNextShiftPage(root: HTMLElement): Promise<void> {
+  await seedZonesIfNeeded();
   const cfg = getConfig();
   const staff = await loadStaff();
   let draft: DraftShift | null = await loadNextDraft();

--- a/src/ui/nextShift/__tests__/NextShiftPage.test.ts
+++ b/src/ui/nextShift/__tests__/NextShiftPage.test.ts
@@ -30,6 +30,10 @@ vi.mock('@/state/staff', () => ({
   loadStaff: vi.fn().mockResolvedValue([{ id: 'n1', name: 'Alice', role: 'nurse' }]),
 }));
 
+vi.mock('@/seed', () => ({
+  seedZonesIfNeeded: vi.fn().mockResolvedValue(undefined),
+}));
+
 describe('renderNextShiftPage', () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="root"></div>';


### PR DESCRIPTION
## Summary
- Ensure Next Shift page seeds default zone configuration when none exist
- Update tests to mock zone seeding helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb0a3ce8e08327ab4e0074407a0b38