### PR TITLE
Fix Next Shift tab not showing zones

### DIFF
--- a/src/ui/nextShift/NextShiftPage.ts
+++ b/src/ui/nextShift/NextShiftPage.ts
@@ -1,5 +1,5 @@
 import './nextShift.css';
-import { getConfig } from '@/state/config';
+import { getConfig, loadConfig } from '@/state/config';
 import { seedZonesIfNeeded } from '@/seed';
 import {
   buildEmptyDraft,
@@ -37,6 +37,7 @@ function readSlot(id: string): Slot | undefined {
 
 /** Render a simple Next Shift planning page with save and publish controls. */
 export async function renderNextShiftPage(root: HTMLElement): Promise<void> {
+  await loadConfig();
   await seedZonesIfNeeded();
   const cfg = getConfig();
   const staff = await loadStaff();

--- a/src/ui/nextShift/__tests__/NextShiftPage.test.ts
+++ b/src/ui/nextShift/__tests__/NextShiftPage.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderNextShiftPage } from '../NextShiftPage';
 
 vi.mock('@/state/config', () => ({
+  loadConfig: vi.fn().mockResolvedValue({ zones: [{ id: 'a', name: 'A' }] }),
   getConfig: () => ({ zones: [{ id: 'a', name: 'A' }] }),
 }));
 


### PR DESCRIPTION
## Summary
- load configuration before seeding next-shift zones so defaults populate
- update Next Shift test to mock config loader

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbe58ac3a08327ad8a29c8ab65b78f