### PR TITLE
Improve weather widget presentation

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -133,6 +133,14 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .widget .title{font-weight:600;color:var(--text-high);display:flex;align-items:center;gap:6px}
 .widget .sub{color:var(--text-med);font-size:.85em}
 
+.weather-card{display:flex;flex-direction:column;gap:8px}
+.weather-current{display:flex;align-items:center;gap:8px}
+.weather-current .temp{font-size:2em;font-weight:600}
+.weather-current svg{width:48px;height:48px}
+.weather-hourly{display:flex;justify-content:space-between;font-size:.8em}
+.weather-hourly .hour{display:flex;flex-direction:column;align-items:center;gap:2px}
+.weather-hourly .hour svg{width:24px;height:24px}
+
 .form-row{margin:8px 0}
 .form-grid{display:grid;grid-template-columns:repeat(3,minmax(200px,1fr));gap:10px}
 .btn-row{display:flex;gap:8px;margin-top:8px}

--- a/src/weather/openMeteo.ts
+++ b/src/weather/openMeteo.ts
@@ -10,7 +10,11 @@ export function buildURL(cfg: OpenMeteoCfg): string {
   url.searchParams.set('longitude', String(cfg.lon));
   url.searchParams.set(
     'hourly',
-    'temperature_2m,relative_humidity_2m,wet_bulb_temperature_2m'
+    'temperature_2m,relative_humidity_2m,wet_bulb_temperature_2m,weathercode'
+  );
+  url.searchParams.set(
+    'daily',
+    'temperature_2m_max,temperature_2m_min'
   );
   url.searchParams.set('timezone', 'auto');
   url.searchParams.set('forecast_days', '3');


### PR DESCRIPTION
## Summary
- fetch daily highs/lows and weather codes from Open-Meteo
- redesign weather widget with descriptive text and hourly forecast
- style widget for expanded layout

## Testing
- `npm test` *(fails: ECONNREFUSED errors to localhost, tests still run)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbe6b1b84083279d09d2c39e6e316c