### PR TITLE
Highlight selected staff in search lists

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -226,6 +226,7 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .assign-col{flex:1;max-height:200px;overflow-y:auto;border:1px solid var(--card-border);border-radius:4px;}
 .assign-item{padding:4px 8px;cursor:pointer;}
 .assign-item:hover{background:var(--control);}
+.assign-item.selected{background:var(--accent);color:#fff;}
 .assign-details{font-size:.9em;margin-top:8px;min-height:1.2em;}
 .history-box{border:1px solid var(--card-border);padding:8px;border-radius:4px;margin-top:8px}
 .banner{background:var(--danger);color:var(--text);padding:8px;text-align:center}

--- a/src/ui/assignDialog.ts
+++ b/src/ui/assignDialog.ts
@@ -51,13 +51,13 @@ export function openAssignDialog(
     nurseCol.innerHTML = nurses
       .map(
         (s) =>
-          `<div class="assign-item" data-id="${s.id}">${s.name || s.id}</div>`
+          `<div class="assign-item${selected === s.id ? ' selected' : ''}" data-id="${s.id}">${s.name || s.id}</div>`
       )
       .join('');
     techCol.innerHTML = techs
       .map(
         (s) =>
-          `<div class="assign-item" data-id="${s.id}">${s.name || s.id}</div>`
+          `<div class="assign-item${selected === s.id ? ' selected' : ''}" data-id="${s.id}">${s.name || s.id}</div>`
       )
       .join('');
     overlay.querySelectorAll('.assign-item').forEach((el) => {
@@ -73,6 +73,9 @@ export function openAssignDialog(
   const select = async (id: string) => {
     selected = id;
     confirm.disabled = false;
+    overlay.querySelectorAll('.assign-item').forEach((el) => {
+      el.classList.toggle('selected', (el as HTMLElement).dataset.id === id);
+    });
     const history = await findShiftsByStaff(id);
     const recent = history.slice(0, 5);
     details.innerHTML = `

--- a/src/ui/nextShift/NextShiftPage.ts
+++ b/src/ui/nextShift/NextShiftPage.ts
@@ -93,6 +93,7 @@ export async function renderNextShiftPage(root: HTMLElement): Promise<void> {
   const goLiveInput = document.getElementById('next-go-live') as HTMLInputElement;
 
   let activeSelect: HTMLSelectElement | null = null;
+  let selected: string | null = null;
   let publishTimer: number | undefined;
 
   function renderStaff(filter = ''): void {
@@ -110,7 +111,7 @@ export async function renderNextShiftPage(root: HTMLElement): Promise<void> {
     nurseCol.innerHTML = nurses
       .map(
         (s) =>
-          `<div class="assign-item" draggable="true" data-id="${s.id}">${
+          `<div class="assign-item${selected === s.id ? ' selected' : ''}" draggable="true" data-id="${s.id}">${
             s.name || s.id
           }</div>`
       )
@@ -118,14 +119,18 @@ export async function renderNextShiftPage(root: HTMLElement): Promise<void> {
     techCol.innerHTML = techs
       .map(
         (s) =>
-          `<div class="assign-item" draggable="true" data-id="${s.id}">${
+          `<div class="assign-item${selected === s.id ? ' selected' : ''}" draggable="true" data-id="${s.id}">${
             s.name || s.id
           }</div>`
       )
       .join('');
-    document.querySelectorAll('.assign-item').forEach((el) => {
+    root.querySelectorAll('.assign-item').forEach((el) => {
       const id = (el as HTMLElement).dataset.id!;
       el.addEventListener('click', () => {
+        selected = id;
+        root.querySelectorAll('.assign-item').forEach((item) => {
+          item.classList.toggle('selected', (item as HTMLElement).dataset.id === id);
+        });
         if (activeSelect) {
           activeSelect.value = id;
         }

--- a/src/ui/nextShift/__tests__/NextShiftPage.test.ts
+++ b/src/ui/nextShift/__tests__/NextShiftPage.test.ts
@@ -90,6 +90,7 @@ describe('renderNextShiftPage', () => {
 
     item.click();
     expect(zoneSel.value).toBe('n1');
+    expect(item.classList.contains('selected')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Highlight selected staff entries using a new `selected` style
- Maintain and display selection state in assign and next-shift dialogs
- Test that search list selection marks the item

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbe7caba608327947a6034e1757c90