### PR TITLE
Link SVG favicon and clarify API troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,11 @@ SetEnv HEYBRE_DATA_DIR "/home/<cpanel-user>/heybre-board-data"
 - Validate with:
   - `GET https://board.heybre.com/api.php?res=staff`
   - Save something from the UI and confirm `active-YYYY-MM-DD-<shift>.json` appears in the data dir.
+
+### Local testing and troubleshooting
+
+- Start a local API server with `php -S localhost:8000 -t server`.
+- Include the required `X-API-Key` header in requests.
+- Check the PHP console output for details on any `500` errors. These are often
+  caused by a missing SQLite extension, an unwritable data directory, or
+  invalid JSON in the request body.

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>StaffBoard V2</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
   </head>
   <body>
     <header id="header"></header>


### PR DESCRIPTION
## Summary
- Reference existing SVG favicon to satisfy browser icon requests
- Document how to run and debug the PHP API locally

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbe66c75bc83278778805a83c007ea