### PR TITLE
feat: drag-and-drop zone assignment on next shift board

### DIFF
--- a/src/ui/nextShift/__tests__/NextShiftPage.test.ts
+++ b/src/ui/nextShift/__tests__/NextShiftPage.test.ts
@@ -40,17 +40,17 @@ describe('renderNextShiftPage', () => {
     document.body.innerHTML = '<div id="root"></div>';
   });
 
-  it('renders zone select and saves draft', async () => {
+  it('renders zone drop and saves draft', async () => {
     const root = document.getElementById('root') as HTMLElement;
     await renderNextShiftPage(root);
 
-    const zoneSel = root.querySelector('select#zone-a') as HTMLSelectElement;
-    expect(zoneSel).toBeTruthy();
+    const zone = root.querySelector('#zone-a') as HTMLElement;
+    expect(zone).toBeTruthy();
 
     const goLive = root.querySelector('#next-go-live') as HTMLInputElement;
     goLive.value = '2024-01-01T07:00';
 
-    zoneSel.value = 'n1';
+    zone.dataset.nurseId = 'n1';
     (root.querySelector('#next-save') as HTMLButtonElement).click();
     await Promise.resolve();
 
@@ -73,7 +73,7 @@ describe('renderNextShiftPage', () => {
     expect(publishNextDraft).toHaveBeenCalled();
   });
 
-  it('filters staff and assigns to the focused select', async () => {
+  it('filters staff list', async () => {
     const root = document.getElementById('root') as HTMLElement;
     await renderNextShiftPage(root);
 
@@ -83,14 +83,10 @@ describe('renderNextShiftPage', () => {
     search.value = 'ali';
     search.dispatchEvent(new Event('input'));
 
-    const zoneSel = root.querySelector('select#zone-a') as HTMLSelectElement;
-    zoneSel.focus();
-
     const item = root.querySelector('.assign-item[data-id="n1"]') as HTMLElement;
     expect(item).toBeTruthy();
 
     item.click();
-    expect(zoneSel.value).toBe('n1');
     expect(item.classList.contains('selected')).toBe(true);
   });
 });

--- a/src/ui/nextShift/nextShift.css
+++ b/src/ui/nextShift/nextShift.css
@@ -13,6 +13,15 @@
   flex-direction: column;
   gap: var(--gap);
 }
+.next-shift .assign-cols {
+  flex: 1;
+  display: flex;
+  gap: var(--gap);
+}
+.next-shift .assign-col {
+  flex: 1;
+  overflow-y: auto;
+}
 .next-shift .assign-panel {
   flex: 2;
   display: flex;
@@ -31,4 +40,9 @@
 .next-shift td {
   padding: 0.25rem;
   text-align: left;
+}
+.next-shift .zone-drop {
+  border: 1px dashed var(--line);
+  min-height: 2rem;
+  padding: 0.25rem;
 }


### PR DESCRIPTION
## Summary
- replace zone selects with drag-and-drop assignments
- stretch staff columns to full height and style drop zones
- show publish time toast when saving next shift

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc7a95ffd48327a2994c5ba124a9f8