### PR TITLE
Revamp staff visuals and simplify settings

### DIFF
--- a/src/state/config.ts
+++ b/src/state/config.ts
@@ -75,6 +75,8 @@ let CONFIG_CACHE: Config = {
     darkPreset: 'dark-charcoal-navy',
     highContrast: false,
     compact: false,
+    iconSize: 1,
+    commentSize: 0.85,
   },
 };
 
@@ -211,6 +213,9 @@ export function mergeConfigDefaults(): Config {
     darkPreset: validDark ? (dark as string) : darkDefault,
     highContrast: cfg.uiTheme?.highContrast === true,
     compact: cfg.uiTheme?.compact === true,
+    iconSize: typeof cfg.uiTheme?.iconSize === 'number' ? cfg.uiTheme.iconSize : 1,
+    commentSize:
+      typeof cfg.uiTheme?.commentSize === 'number' ? cfg.uiTheme.commentSize : 0.85,
   };
 
   // Misc

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -227,6 +227,8 @@ let CONFIG_CACHE: Config = {
     darkPreset: 'dark-charcoal-navy',
     highContrast: false,
     compact: false,
+    iconSize: 1,
+    commentSize: 0.85,
   },
 };
 
@@ -361,6 +363,9 @@ export function mergeConfigDefaults(): Config {
     darkPreset: validDark ? (dark as string) : darkDefault,
     highContrast: cfg.uiTheme?.highContrast === true,
     compact: cfg.uiTheme?.compact === true,
+    iconSize: typeof cfg.uiTheme?.iconSize === 'number' ? cfg.uiTheme.iconSize : 1,
+    commentSize:
+      typeof cfg.uiTheme?.commentSize === 'number' ? cfg.uiTheme.commentSize : 0.85,
   };
 
   // Misc

--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -36,6 +36,8 @@ export interface UIThemeConfig {
   custom?: Partial<ThemeTokens>;
   highContrast?: boolean;
   compact?: boolean;
+  iconSize?: number;
+  commentSize?: number;
 }
 
 /** Available light and dark presets. */
@@ -240,6 +242,8 @@ const DEFAULT_THEME: UIThemeConfig = {
   scale: 1,
   lightPreset: 'light-soft-gray',
   darkPreset: 'dark-charcoal-navy',
+  iconSize: 1,
+  commentSize: 0.85,
 };
 
 /** Get the current theme configuration merged with defaults. */
@@ -260,6 +264,8 @@ export async function saveThemeConfig(partial: Partial<UIThemeConfig>): Promise<
 export function applyTheme(cfg: UIThemeConfig = getThemeConfig()): void {
   const r = document.documentElement;
   r.style.setProperty('--scale', String(cfg?.scale ?? 1));
+  r.style.setProperty('--nurse-icon-size', `${cfg.iconSize ?? 1}em`);
+  r.style.setProperty('--comment-text-size', `${cfg.commentSize ?? 0.85}em`);
   const mode = cfg?.mode ?? 'system';
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   const isDark = mode === 'dark' || (mode === 'system' && prefersDark);

--- a/src/styles.css
+++ b/src/styles.css
@@ -155,34 +155,12 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .assignment-card{background:var(--control);border:1px solid var(--line);border-radius:14px;padding:10px 12px;min-height:84px;box-shadow:var(--elev-1)}
 
 /* color-coded nurse pills */
-.nurse-pill{
-  position:relative;display:flex;align-items:center;gap:8px;
-  padding:6px 10px;border-radius:999px;
-  background: var(--pill, var(--control));
-  border:1px solid var(--line);
-  color:var(--zone-fg);
-}
-.nurse-pill[data-type]{
-  color:var(--pill-fg);
-}
-.nurse-pill[data-type] .nurse-meta{
-  color:var(--pill-meta-fg);
-}
-.nurse-pill[data-type="home"]{--pill:var(--accent-home)}
-.nurse-pill[data-type="travel"]{--pill:var(--accent-travel)}
-.nurse-pill[data-type="flex"]{--pill:var(--accent-flex)}
-.nurse-pill[data-type="charge"]{--pill:var(--accent-charge)}
-.nurse-pill[data-type="triage"]{--pill:var(--accent-triage)}
-.nurse-pill[data-type="other"]{--pill:var(--accent-other)}
-.nurse-pill::before{content:"";position:absolute;inset:0;border-radius:inherit;box-shadow:0 0 0 2px var(--pill) inset,var(--halo);opacity:.75;pointer-events:none}
-.nurse-name{font-weight:600}
-.nurse-meta{color:var(--text-med);font-size:.85em}
 .chips{margin-left:auto;display:flex;gap:6px}
 .chip{display:inline-flex;align-items:center;gap:4px;padding:2px 6px;border-radius:999px;background:rgba(255,255,255,.06);color:var(--text-med);border:1px solid var(--line);font-size:.75em;line-height:1}
-.chip .icon{font-size:1em}
+.chip .icon{font-size:var(--nurse-icon-size,1em)}
 
 /* no color-mix: simple currentColor outline */
-.nurse-pill:focus-visible,.chip:focus-visible{outline:2px solid currentColor;outline-offset:2px}
+.chip:focus-visible{outline:2px solid currentColor;outline-offset:2px}
 
 @media print{
   #widgets,.widget{display:none!important}

--- a/src/ui/mainBoard/boardLayout.css
+++ b/src/ui/mainBoard/boardLayout.css
@@ -87,6 +87,14 @@
   text-overflow: ellipsis;
 }
 
+.nurse-card__comment {
+  color: var(--text-med);
+  font-size: var(--comment-text-size, .85em);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .nurse-card:focus-visible {
   outline: 2px solid var(--ring);
   outline-offset: 2px;

--- a/src/ui/nurseTile.ts
+++ b/src/ui/nurseTile.ts
@@ -1,4 +1,4 @@
-import type { Slot } from '../slots';
+import type { Slot } from '@/slots';
 import type { Staff } from '@/state/staff';
 import { getConfig } from '@/state/config';
 import { formatName } from '@/utils/names';
@@ -7,17 +7,12 @@ export function nurseTile(slot: Slot, staff: Staff): string {
   const chips: string[] = [];
   if (slot.break?.active) {
     chips.push(
-      `<span class="chip" aria-label="On break"><span class="icon">⏸️</span></span>`
+      `<span class="chip" aria-label="On break"><span class="icon">☕</span></span>`
     );
   }
   if (slot.student) {
     chips.push(
       `<span class="chip" aria-label="Has student"><span class="icon">🎓</span></span>`
-    );
-  }
-  if (slot.comment) {
-    chips.push(
-      `<span class="chip" aria-label="Has comment"><span class="icon">💬</span></span>`
     );
   }
   if (slot.bad) {
@@ -35,20 +30,32 @@ export function nurseTile(slot: Slot, staff: Staff): string {
     true;
 
   const name = formatName(staff.name || '', privacy);
-  const meta = `${staff.type ?? 'other'} ${staff.role ?? 'nurse'}`.trim();
+  const metaBase = `${staff.type ?? 'other'} ${staff.role ?? 'nurse'}`.trim();
+  const typeIcons: Record<string, string> = {
+    home: '🏠',
+    travel: '✈️',
+    flex: '🔁',
+    charge: '⭐',
+    triage: '🚨',
+  };
+  const typeIcon = typeIcons[staff.type ?? ''] || '';
+  const meta = typeIcon ? `${typeIcon} ${metaBase}` : metaBase;
 
   const statuses: string[] = [];
   if (slot.break?.active) statuses.push('on break');
   if (slot.student) statuses.push('has student');
-  if (slot.comment) statuses.push('has comment');
   if (slot.bad) statuses.push('marked bad');
 
   const aria =
     `${name}` +
-    (meta ? `, ${meta}` : '') +
+    (metaBase ? `, ${metaBase}` : '') +
+    (slot.comment ? `, comment ${slot.comment}` : '') +
     (statuses.length ? `, ${statuses.join(', ')}` : '');
 
   const chipStr = chips.length ? `<span class="chips">${chips.join('')}</span>` : '';
+  const commentHtml = slot.comment
+    ? `<div class="nurse-card__comment"><span class="icon">💬</span> ${slot.comment}</div>`
+    : '';
 
-  return `<div class="nurse-card" data-type="${staff.type ?? 'other'}" data-role="${staff.role ?? 'nurse'}" tabindex="0" aria-label="${aria}"><div class="nurse-card__text"><div class="nurse-card__name">${name}</div><div class="nurse-card__meta">${meta}</div></div>${chipStr}</div>`;
+  return `<div class="nurse-card" data-type="${staff.type ?? 'other'}" data-role="${staff.role ?? 'nurse'}" tabindex="0" aria-label="${aria}"><div class="nurse-card__text"><div class="nurse-card__name">${name}</div><div class="nurse-card__meta">${meta}</div>${commentHtml}</div>${chipStr}</div>`;
 }

--- a/tests/slots.spec.ts
+++ b/tests/slots.spec.ts
@@ -65,7 +65,7 @@ describe("break toggles", () => {
       role: "nurse",
       type: "other",
     });
-    expect(html).toContain("⏸️");
+    expect(html).toContain("☕");
     endBreak(slot);
     expect(slot.break?.active).toBe(false);
   });
@@ -106,7 +106,7 @@ describe("nurse tile snapshot", () => {
       type: "other",
     });
     expect(html).toMatchInlineSnapshot(
-      `"<div class=\"nurse-card\" data-type=\"other\" data-role=\"nurse\" tabindex=\"0\" aria-label=\"Alice, other nurse, on break, has student, has comment, marked bad\"><div class=\"nurse-card__text\"><div class=\"nurse-card__name\">Alice</div><div class=\"nurse-card__meta\">other nurse</div></div><span class=\"chips\"><span class=\"chip\" aria-label=\"On break\"><span class=\"icon\">⏸️</span></span><span class=\"chip\" aria-label=\"Has student\"><span class=\"icon\">🎓</span></span><span class=\"chip\" aria-label=\"Has comment\"><span class=\"icon\">💬</span></span><span class=\"chip\" aria-label=\"Marked bad\"><span class=\"icon\">⚠️</span></span></span></div>"`
+      `"<div class=\"nurse-card\" data-type=\"other\" data-role=\"nurse\" tabindex=\"0\" aria-label=\"Alice, other nurse, comment note, on break, has student, marked bad\"><div class=\"nurse-card__text\"><div class=\"nurse-card__name\">Alice</div><div class=\"nurse-card__meta\">other nurse</div><div class=\"nurse-card__comment\"><span class=\"icon\">💬</span> note</div></div><span class=\"chips\"><span class=\"chip\" aria-label=\"On break\"><span class=\"icon\">☕</span></span><span class=\"chip\" aria-label=\"Has student\"><span class=\"icon\">🎓</span></span><span class=\"chip\" aria-label=\"Marked bad\"><span class=\"icon\">⚠️</span></span></span></div>"`
     );
   });
 });

--- a/tests/themeConfig.spec.ts
+++ b/tests/themeConfig.spec.ts
@@ -15,7 +15,7 @@ vi.mock('@/db', () => {
   };
 });
 
-import { saveConfig } from '@/state/config';
+import { saveConfig } from '@/state';
 import { getThemeConfig } from '@/state/theme';
 
 describe('theme config presets', () => {
@@ -24,5 +24,12 @@ describe('theme config presets', () => {
     const cfg = getThemeConfig();
     expect(cfg.lightPreset).toBe('light-soft-gray');
     expect(cfg.darkPreset).toBe('dark-charcoal-navy');
+  });
+
+  it('persists icon and comment sizes', async () => {
+    await saveConfig({ uiTheme: { iconSize: 1.2, commentSize: 0.9 } as any });
+    const cfg = getThemeConfig();
+    expect(cfg.iconSize).toBe(1.2);
+    expect(cfg.commentSize).toBe(0.9);
   });
 });


### PR DESCRIPTION
## Summary
- show staff comments beneath position with bubble icon
- update break and student icons and add type glyphs for home/travel/flex
- drop unused nurse type legend and zone color picker from settings
- allow tuning nurse icon and comment text sizes in visual settings

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc7a041c78832787eacbbb3674aed3