### PR TITLE
Defer assignment end timestamps until completion

### DIFF
--- a/src/history/index.ts
+++ b/src/history/index.ts
@@ -58,7 +58,7 @@ export function exportShiftCSV(snapshot: PublishedShiftSnapshot): string {
         a.displayName,
         a.role,
         a.startISO,
-        a.endISO,
+        a.endISO ?? '',
         a.dto ? '1' : '0',
       ].join(',')
     )
@@ -84,7 +84,7 @@ export function exportNurseHistoryCSV(entries: NurseShiftIndexEntry[]): string {
         e.zone,
         e.previousZone ?? '',
         e.startISO,
-        e.endISO,
+        e.endISO ?? '',
         e.dto ? '1' : '0',
       ].join(',')
     )

--- a/src/state/board.ts
+++ b/src/state/board.ts
@@ -157,7 +157,6 @@ export async function applyDraftToActive(
         role: info?.role || 'nurse',
         zone,
         startISO: now,
-        endISO: now,
         dto: slot.dto
           ? { effectiveISO: now, offgoingUntilISO: now }
           : undefined,
@@ -174,7 +173,6 @@ export async function applyDraftToActive(
       role: info?.role || 'nurse',
       zone: 'Charge',
       startISO: now,
-      endISO: now,
     });
   }
   if (draft.triage?.nurseId) {
@@ -185,7 +183,6 @@ export async function applyDraftToActive(
       role: info?.role || 'nurse',
       zone: 'Triage',
       startISO: now,
-      endISO: now,
     });
   }
   if (draft.admin?.nurseId) {
@@ -196,7 +193,6 @@ export async function applyDraftToActive(
       role: info?.role || 'nurse',
       zone: 'Secretary',
       startISO: now,
-      endISO: now,
     });
   }
   const huddle = await getHuddle(dateISO, shift as ShiftKind);

--- a/src/state/history.ts
+++ b/src/state/history.ts
@@ -117,7 +117,7 @@ export interface Assignment {
   role: RoleKind;
   zone: string;
   startISO: string;
-  endISO: string;
+  endISO?: string;
   dto?: {
     effectiveISO: string;
     offgoingUntilISO: string;
@@ -175,7 +175,7 @@ export interface NurseShiftIndexEntry {
   zone: string;
   previousZone?: string;
   startISO: string;
-  endISO: string;
+  endISO?: string;
   dto?: boolean;
 }
 
@@ -246,7 +246,7 @@ export async function indexStaffAssignments(
   await ensureVersion();
   for (const a of snapshot.zoneAssignments) {
     const start = new Date(a.startISO).getTime();
-    const end = new Date(a.endISO).getTime();
+    const end = a.endISO ? new Date(a.endISO).getTime() : NaN;
     if (isFinite(start) && isFinite(end)) {
       const minutes = (end - start) / 60000;
       if (minutes < 20) continue;
@@ -266,7 +266,7 @@ export async function indexStaffAssignments(
       zone: a.zone,
       previousZone: prevZone,
       startISO: a.startISO,
-      endISO: a.endISO,
+      ...(a.endISO ? { endISO: a.endISO } : {}),
       dto: !!a.dto,
     };
     list.unshift(entry);

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -478,7 +478,6 @@ export async function applyDraftToActive(
         role: info?.role || 'nurse',
         zone,
         startISO: now,
-        endISO: now,
         dto: slot.dto
           ? { effectiveISO: now, offgoingUntilISO: now }
           : undefined,
@@ -495,7 +494,6 @@ export async function applyDraftToActive(
       role: info?.role || 'nurse',
       zone: 'Charge',
       startISO: now,
-      endISO: now,
     });
   }
   if (draft.triage?.nurseId) {
@@ -506,7 +504,6 @@ export async function applyDraftToActive(
       role: info?.role || 'nurse',
       zone: 'Triage',
       startISO: now,
-      endISO: now,
     });
   }
   if (draft.admin?.nurseId) {
@@ -517,7 +514,6 @@ export async function applyDraftToActive(
       role: info?.role || 'nurse',
       zone: 'Secretary',
       startISO: now,
-      endISO: now,
     });
   }
   const huddle = await getHuddle(dateISO, shift as ShiftKind);

--- a/tests/draftApply.spec.ts
+++ b/tests/draftApply.spec.ts
@@ -41,5 +41,12 @@ describe('applyDraftToActive', () => {
 
     expect(await DB.get(KS.ACTIVE(board.dateISO, board.shift))).toEqual(board);
     expect(await DB.get(KS.DRAFT(board.dateISO, board.shift))).toBeUndefined();
+
+    const snap = await DB.get(
+      `history:shift:${board.dateISO}:${board.shift}`
+    );
+    expect(snap.zoneAssignments[0].endISO).toBeUndefined();
+    const charge = snap.zoneAssignments.find((a: any) => a.zone === 'Charge');
+    expect(charge.endISO).toBeUndefined();
   });
 });

--- a/tests/history.spec.ts
+++ b/tests/history.spec.ts
@@ -93,6 +93,24 @@ describe('history persistence', () => {
     expect(rows[0].dto).toBe(true);
   });
 
+  it('handles assignments without endISO', async () => {
+    const snap: PublishedShiftSnapshot = {
+      ...base,
+      zoneAssignments: [
+        {
+          staffId: '1',
+          displayName: 'Alice',
+          role: 'nurse',
+          zone: 'A',
+          startISO: '2024-01-01T07:00:00.000Z',
+        },
+      ],
+    };
+    await indexStaffAssignments(snap);
+    const rows = await findShiftsByStaff('1');
+    expect(rows[0].endISO).toBeUndefined();
+  });
+
   it('records previous zone when nurse moves', async () => {
     const first: PublishedShiftSnapshot = {
       ...base,


### PR DESCRIPTION
## Summary
- stop auto-setting `endISO` when publishing shifts so it remains unset until sign-off
- allow history snapshots and exports to handle missing `endISO`
- add tests for open assignments without end timestamps

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc7c40c85483278ca5b06cc7c9da19