### PR TITLE
refactor: reorganize settings layout

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -189,6 +189,8 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .roster-row{display:flex;align-items:center;justify-content:space-between;padding:4px;cursor:pointer}
 .roster-row.selected{background:var(--tab)}
 .settings-pane{display:flex;flex-direction:column;gap:16px}
+.zones-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:8px}
+.zones-grid .form-row{margin:0}
 .zone-card{border:1px solid var(--line);border-radius:8px;padding:6px;background:var(--panel)}
 .zone-card h4{margin:0 0 4px}
 .roster-controls{display:flex;flex-direction:column;gap:6px}

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -25,9 +25,9 @@ export async function renderSettings(root: HTMLElement): Promise<void> {
       <div class="settings-pane">
         <div id="nurse-editor" data-testid="nurse-editor"></div>
         <div id="general-settings" data-testid="general-settings"></div>
-        <div id="display-settings" data-testid="display-settings"></div>
       </div>
     </div>
+    <div id="display-settings" data-testid="display-settings"></div>
     <div id="settings-widgets"></div>
   `;
   await renderRosterPane();
@@ -189,14 +189,12 @@ function renderGeneralSettings() {
   const cfg = getConfig();
   const ui = getUIConfig();
   const el = document.getElementById('general-settings')!;
-  const zonesHTML = cfg.zones
+  const zonesHTML = `<div class="zones-grid">${cfg.zones
     .map(
       (z, i) =>
-        `<div class="form-row zone-row">
-          <input class="zone-name" data-index="${i}" value="${z.name}">
-        </div>`
+        `<div class="form-row zone-row"><input class="zone-name" data-index="${i}" value="${z.name}"></div>`
     )
-    .join('');
+    .join('')}</div>`;
   el.innerHTML = `
     <section class="panel">
       <h3>General</h3>


### PR DESCRIPTION
## Summary
- group staff editor with zone editing and move display and widget settings below
- arrange zone inputs in responsive multi-column grid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be3d55459c832783490ef7f3c05c07