### PR TITLE
Add shift end time and shift-end warnings

### DIFF
--- a/src/state/board.ts
+++ b/src/state/board.ts
@@ -19,6 +19,7 @@ export const CURRENT_SCHEMA_VERSION = 2;
 export interface ActiveShift {
   dateISO: string;
   shift: Shift;
+  endAtISO?: string;
   charge?: Slot;
   triage?: Slot;
   admin?: Slot;
@@ -73,6 +74,15 @@ export function migrateActiveBoard(raw: any): ActiveBoard {
   return {
     dateISO: raw?.dateISO ?? toDateISO(new Date()),
     shift: raw?.shift === 'night' ? 'night' : 'day',
+    endAtISO:
+      typeof raw?.endAtISO === 'string'
+        ? raw.endAtISO
+        : (() => {
+            const startHH = raw?.shift === 'night' ? '19:00' : '07:00';
+            const d = new Date(`${raw?.dateISO ?? toDateISO(new Date())}T${startHH}`);
+            d.setHours(d.getHours() + 12);
+            return d.toISOString();
+          })(),
     charge: raw?.charge ?? undefined,
     triage: raw?.triage ?? undefined,
     admin: raw?.admin ?? undefined,
@@ -104,6 +114,15 @@ export function migrateDraft(raw: any): DraftShift {
   return {
     dateISO: raw?.dateISO ?? toDateISO(new Date()),
     shift: raw?.shift === 'night' ? 'night' : 'day',
+    endAtISO:
+      typeof raw?.endAtISO === 'string'
+        ? raw.endAtISO
+        : (() => {
+            const startHH = raw?.shift === 'night' ? '19:00' : '07:00';
+            const d = new Date(`${raw?.dateISO ?? toDateISO(new Date())}T${startHH}`);
+            d.setHours(d.getHours() + 12);
+            return d.toISOString();
+          })(),
     charge: raw?.charge ?? undefined,
     triage: raw?.triage ?? undefined,
     admin: raw?.admin ?? undefined,

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -83,6 +83,7 @@ export const CURRENT_SCHEMA_VERSION = 2;
 export interface ActiveShift {
   dateISO: string;
   shift: Shift;
+  endAtISO?: string;
   charge?: Slot;
   triage?: Slot;
   admin?: Slot;
@@ -385,6 +386,15 @@ export function migrateActiveBoard(raw: unknown): ActiveBoard {
   return {
     dateISO: r?.dateISO ?? toDateISO(new Date()),
     shift: r?.shift === 'night' ? 'night' : 'day',
+    endAtISO:
+      typeof r?.endAtISO === 'string'
+        ? r.endAtISO
+        : (() => {
+            const startHH = r?.shift === 'night' ? '19:00' : '07:00';
+            const d = new Date(`${r?.dateISO ?? toDateISO(new Date())}T${startHH}`);
+            d.setHours(d.getHours() + 12);
+            return d.toISOString();
+          })(),
     charge: r?.charge ?? undefined,
     triage: r?.triage ?? undefined,
     admin: r?.admin ?? undefined,

--- a/src/state/nextShift.ts
+++ b/src/state/nextShift.ts
@@ -10,6 +10,7 @@ import { type ZoneDef } from '@/utils/zones';
 
 export interface DraftShift extends BaseDraftShift {
   publishAtISO?: string;
+  endAtISO?: string;
 }
 
 /** Build an empty draft with zones populated but no assignments. */
@@ -31,6 +32,7 @@ export function buildEmptyDraft(
     handoff: '',
     version: CURRENT_SCHEMA_VERSION,
     publishAtISO: undefined,
+    endAtISO: undefined,
   };
 }
 

--- a/tests/board.spec.ts
+++ b/tests/board.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('@/state', () => ({
   getConfig: () => ({ showPinned: {} }),
+  getActiveBoardCache: () => undefined,
 }));
 
 import { renderLeadership } from '@/ui/board';

--- a/tests/manageOverlayPersist.spec.ts
+++ b/tests/manageOverlayPersist.spec.ts
@@ -36,6 +36,7 @@ vi.mock('@/state', () => {
     CURRENT_SCHEMA_VERSION: 1,
     migrateActiveBoard: (a: any) => a,
     setActiveBoardCache: () => {},
+    getActiveBoardCache: () => store[KS.ACTIVE(STATE.dateISO, STATE.shift)],
     DB: {
       get: async (k: string) => store[k],
       set: async (k: string, v: any) => { store[k] = v; },


### PR DESCRIPTION
## Summary
- add end time field on Next Shift tab
- default missing shift end to 12 hours after start
- show open door icon when a shift has one hour remaining
- auto-populate start/end times to the next standard shift

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be3d1a9d44832784d3cdeed4f3a0cd