### PR TITLE
Handle physicians without times or locations

### DIFF
--- a/src/ui/physicians.ts
+++ b/src/ui/physicians.ts
@@ -221,7 +221,10 @@ export async function renderPhysicians(el: HTMLElement, dateISO: string): Promis
       return `${hour}${suffix}`;
     };
 
-    const items = docs.map((d) => `<li>${formatTime(d.time)} ${d.name}</li>`).join('');
+    const allMidnight = docs.every((d) => d.time === '00:00');
+    const items = allMidnight
+      ? docs.map((d) => `<li>${d.name}</li>`).join('')
+      : docs.map((d) => `<li>${formatTime(d.time)} ${d.name}</li>`).join('');
     el.innerHTML = `<ul class="phys-list">${items}</ul>`;
   } catch {
     el.textContent = 'Physician schedule unavailable';
@@ -242,7 +245,7 @@ export async function getUpcomingDoctors(
   const map: Record<string, Record<string, string[]>> = {};
   for (const e of events) {
     const t = new Date(e.date + 'T00:00:00').getTime();
-    const locName = e.location ? normalizeLocation(e.location) : null;
+    const locName = e.location ? normalizeLocation(e.location) : 'Downtown';
     if (t >= start && t < end && locName) {
       const name = extractDoctor(e.summary.trim());
       if (name) {

--- a/tests/physiciansDom.spec.ts
+++ b/tests/physiciansDom.spec.ts
@@ -53,6 +53,54 @@ describe('physician schedule rendering', () => {
     expect(text).toContain('10pm Dr. Fischer');
   });
 
+  it('handles events without explicit start times', async () => {
+    const sample = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'DTSTART:20240101T000000',
+      'ATTENDEE;CN="Dr Bayers":mailto:bayers@example.com',
+      'ATTENDEE;CN="Dr Fox":mailto:fox@example.com',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\n');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: { get: () => 'text/calendar' },
+        text: () => Promise.resolve(sample),
+      } as unknown as Response)
+    );
+
+    const el = document.createElement('div');
+    await phys.renderPhysicians(el, '2024-01-01');
+    const items = Array.from(el.querySelectorAll('li')).map((li) => li.textContent?.trim());
+    expect(items).toEqual(['Dr. Bayers', 'Dr. Fox']);
+  });
+
+  it('aggregates upcoming physicians without locations', async () => {
+    const sample = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'DTSTART:20240101T000000',
+      'ATTENDEE;CN="Dr Bayers":mailto:bayers@example.com',
+      'ATTENDEE;CN="Dr Fox":mailto:fox@example.com',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\n');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: { get: () => 'text/calendar' },
+        text: () => Promise.resolve(sample),
+      } as unknown as Response)
+    );
+
+    const data = await phys.getUpcomingDoctors('2024-01-01', 1);
+    expect(data).toEqual({ '2024-01-01': { Downtown: ['Dr. Bayers', 'Dr. Fox'] } });
+  });
+
   // Popup rendering is indirectly covered via renderPhysicians tests.
 });
 


### PR DESCRIPTION
## Summary
- Hide placeholder 12am when physician schedule lacks times
- Default physician location to Downtown when missing
- Add tests for all-day physician events and location grouping

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be4071c17c832795392f8cf48b1431