### PR TITLE
Allow zone containers to grow with content

### DIFF
--- a/src/ui/mainBoard/boardLayout.css
+++ b/src/ui/mainBoard/boardLayout.css
@@ -31,7 +31,6 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  overflow-y: auto;
   min-height: 60px;
   padding: 10px;
   position: relative;


### PR DESCRIPTION
## Summary
- remove fixed overflow from zone card body so containers expand for content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be4129dcc883278cc50b58d47f163b