### PR TITLE
feat: add storage-based sync fallback

### DIFF
--- a/src/state/sync.ts
+++ b/src/state/sync.ts
@@ -1,17 +1,28 @@
 /**
  * Simple cross-tab synchronization using BroadcastChannel.
+ * Falls back to `localStorage` events when unavailable.
  */
 const channel: BroadcastChannel | null =
   typeof BroadcastChannel === 'undefined'
     ? null
     : new BroadcastChannel('staffboard-sync');
 
+const FALLBACK_KEY = 'staffboard-sync';
+
 /**
  * Notify other tabs that a key has been updated.
  * @param key Storage key that changed.
  */
 export function notifyUpdate(key: string): void {
-  channel?.postMessage({ key });
+  if (channel) {
+    channel.postMessage({ key });
+  } else if (typeof localStorage !== 'undefined') {
+    try {
+      localStorage.setItem(FALLBACK_KEY, `${key}:${Date.now()}`);
+    } catch {
+      // ignore storage quota errors
+    }
+  }
 }
 
 /**
@@ -20,7 +31,15 @@ export function notifyUpdate(key: string): void {
  * @param handler Callback when the key is updated.
  */
 export function onUpdate(key: string, handler: () => void): void {
-  channel?.addEventListener('message', (ev) => {
-    if (ev.data?.key === key) handler();
-  });
+  if (channel) {
+    channel.addEventListener('message', (ev) => {
+      if (ev.data?.key === key) handler();
+    });
+  } else if (typeof window !== 'undefined') {
+    window.addEventListener('storage', (ev) => {
+      if (ev.key === FALLBACK_KEY && ev.newValue?.startsWith(`${key}:`)) {
+        handler();
+      }
+    });
+  }
 }

--- a/tests/sync.spec.ts
+++ b/tests/sync.spec.ts
@@ -1,0 +1,25 @@
+/** @vitest-environment happy-dom */
+import { describe, it, expect, vi } from 'vitest';
+
+describe('sync fallback', () => {
+  it('uses storage events when BroadcastChannel is unavailable', async () => {
+    const origBC = (globalThis as any).BroadcastChannel;
+    // remove BroadcastChannel to trigger fallback
+    // @ts-ignore
+    delete (globalThis as any).BroadcastChannel;
+    vi.resetModules();
+
+    const { notifyUpdate, onUpdate } = await import('@/state/sync');
+
+    const handler = vi.fn();
+    onUpdate('foo', handler);
+    notifyUpdate('foo');
+    const val = window.localStorage.getItem('staffboard-sync');
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: 'staffboard-sync', newValue: val ?? '' })
+    );
+    expect(handler).toHaveBeenCalled();
+
+    (globalThis as any).BroadcastChannel = origBC;
+  });
+});


### PR DESCRIPTION
## Summary
- use localStorage events to synchronize when BroadcastChannel is unavailable
- test storage-based sync fallback

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be4878e2408327b7238cdc6147ddae