### PR TITLE
Use CSP frame-ancestors instead of X-Frame-Options

### DIFF
--- a/server/api.php
+++ b/server/api.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 header('Content-Type: application/json; charset=utf-8');
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 header('Pragma: no-cache');
+header("Content-Security-Policy: frame-ancestors 'none'");
 
 $ROOT_DIR = __DIR__;
 $DATA_DIR = $ROOT_DIR . '/data';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,16 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   base: '/',
   resolve: { alias: { '@': resolve(__dirname, 'src') } },
+  server: {
+    headers: {
+      'Content-Security-Policy': "frame-ancestors 'none'",
+    },
+  },
+  preview: {
+    headers: {
+      'Content-Security-Policy': "frame-ancestors 'none'",
+    },
+  },
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary
- send `Content-Security-Policy: frame-ancestors 'none'` header for API and Vite dev/preview servers
- stop relying on deprecated `X-Frame-Options`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be48bf8bd48327a6c15b1027811efc