### PR TITLE
Avoid deprecated unload event by using pagehide

### DIFF
--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -206,7 +206,7 @@ export async function renderBoard(
       if (document.hidden) void flushSave();
     });
 
-    window.addEventListener('beforeunload', () => {
+    window.addEventListener('pagehide', () => {
       void flushSave();
     });
 


### PR DESCRIPTION
## Summary
- Use `pagehide` instead of `beforeunload` to flush board changes before navigating away

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be48e325a083278664fb717bd64d7a