### PR TITLE
chore: remove deprecated Pragma headers

### DIFF
--- a/api.php
+++ b/api.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 header('Content-Type: application/json; charset=utf-8');
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
-header('Pragma: no-cache');
 
 $DATA_DIR = __DIR__ . '/data';
 if (!is_dir($DATA_DIR)) {

--- a/server/api.php
+++ b/server/api.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
 
 header('Content-Type: application/json; charset=utf-8');
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
-header('Pragma: no-cache');
 
 $ROOT_DIR = __DIR__;
 $DATA_DIR = $ROOT_DIR . '/data';


### PR DESCRIPTION
## Summary
- remove deprecated `Pragma` header from PHP API endpoints

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be48c8395083279483c1a906cd41b8