### PR TITLE
fix: use HTML content type for physicians endpoint

### DIFF
--- a/api.php
+++ b/api.php
@@ -230,7 +230,7 @@ switch ($action) {
   }
 
   case 'physicians': {
-    header('Content-Type: text/calendar; charset=utf-8');
+    header('Content-Type: text/html; charset=utf-8');
     $cachePath = $DATA_DIR . '/physicians.ics';
     $ttl = 300; // 5 minutes
     $ics = null;


### PR DESCRIPTION
## Summary
- use text/html header for physicians endpoint to avoid mislabelled calendar content type

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be48f015348327922fab447fb4b986