### PR TITLE
Persist board state across tabs and refresh

### DIFF
--- a/src/state/board.ts
+++ b/src/state/board.ts
@@ -58,14 +58,17 @@ export function initState(): void {
   STATE.shift = deriveShift(STATE.clockHHMM);
 }
 
-let ACTIVE_BOARD_CACHE: ActiveBoard | undefined;
+const ACTIVE_BOARD_CACHE: Record<string, ActiveBoard> = {};
 /** Cache the current active board */
 export function setActiveBoardCache(board: ActiveBoard): void {
-  ACTIVE_BOARD_CACHE = board;
+  ACTIVE_BOARD_CACHE[KS.ACTIVE(board.dateISO, board.shift)] = board;
 }
 /** Retrieve the cached active board */
-export function getActiveBoardCache(): ActiveBoard | undefined {
-  return ACTIVE_BOARD_CACHE;
+export function getActiveBoardCache(
+  dateISO: string,
+  shift: Shift
+): ActiveBoard | undefined {
+  return ACTIVE_BOARD_CACHE[KS.ACTIVE(dateISO, shift)];
 }
 
 /** Migrate possibly older active board structures */

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -121,12 +121,15 @@ export function initState() {
   STATE.shift = deriveShift(STATE.clockHHMM);
 }
 
-let ACTIVE_BOARD_CACHE: ActiveBoard | undefined;
+const ACTIVE_BOARD_CACHE: Record<string, ActiveBoard> = {};
 export function setActiveBoardCache(board: ActiveBoard): void {
-  ACTIVE_BOARD_CACHE = board;
+  ACTIVE_BOARD_CACHE[KS.ACTIVE(board.dateISO, board.shift)] = board;
 }
-export function getActiveBoardCache(): ActiveBoard | undefined {
-  return ACTIVE_BOARD_CACHE;
+export function getActiveBoardCache(
+  dateISO: string,
+  shift: Shift
+): ActiveBoard | undefined {
+  return ACTIVE_BOARD_CACHE[KS.ACTIVE(dateISO, shift)];
 }
 
 /** Merge a local board into the remote one without overwriting remote edits. */

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -81,7 +81,10 @@ export async function renderBoard(
     const saveKey = KS.ACTIVE(ctx.dateISO, ctx.shift);
 
     // Prefer in-memory cache to preserve unsaved edits when switching tabs
-    let active: ActiveBoard | undefined = getActiveBoardCache();
+    let active: ActiveBoard | undefined = getActiveBoardCache(
+      ctx.dateISO,
+      ctx.shift
+    );
     let usedLocal = !!active;
 
     try {

--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -75,7 +75,7 @@ export function renderHeader() {
       const tasks: Promise<any>[] = [];
 
       const local =
-        getActiveBoardCache() ??
+        getActiveBoardCache(STATE.dateISO, shift) ??
         (await DB.get<ActiveBoard>(KS.ACTIVE(STATE.dateISO, shift)));
       if (local) {
         const remote = await Server.load('active', {

--- a/src/ui/nurseTile.ts
+++ b/src/ui/nurseTile.ts
@@ -1,7 +1,7 @@
 import type { Slot } from '@/slots';
 import type { Staff } from '@/state/staff';
 import { getConfig } from '@/state/config';
-import { getActiveBoardCache } from '@/state';
+import { getActiveBoardCache, STATE } from '@/state';
 import { formatName } from '@/utils/names';
 
 export function nurseTile(slot: Slot, staff: Staff): string {
@@ -22,7 +22,10 @@ export function nurseTile(slot: Slot, staff: Staff): string {
     );
   }
 
-  const board = typeof getActiveBoardCache === 'function' ? getActiveBoardCache() : undefined;
+  const board =
+    typeof getActiveBoardCache === 'function'
+      ? getActiveBoardCache(STATE.dateISO, STATE.shift)
+      : undefined;
   const cfg = (typeof getConfig === 'function' ? getConfig() : {}) as any;
   let endISO = board?.endAtISO;
   if (!endISO && board) {

--- a/tests/activeBoardCache.spec.ts
+++ b/tests/activeBoardCache.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { setActiveBoardCache, getActiveBoardCache } from '@/state';
+
+import type { ActiveBoard } from '@/state';
+
+describe('active board cache', () => {
+  it('returns board only for matching date and shift', () => {
+    const board: ActiveBoard = {
+      dateISO: '2024-01-01',
+      shift: 'day',
+      charge: undefined,
+      triage: undefined,
+      admin: undefined,
+      zones: {},
+      incoming: [],
+      offgoing: [],
+      comments: '',
+      huddle: '',
+      handoff: '',
+      version: 1,
+    };
+    setActiveBoardCache(board);
+    expect(getActiveBoardCache('2024-01-01', 'day')).toBe(board);
+    expect(getActiveBoardCache('2024-01-02', 'day')).toBeUndefined();
+    expect(getActiveBoardCache('2024-01-01', 'night')).toBeUndefined();
+  });
+});

--- a/tests/activeBoardServerPersist.spec.ts
+++ b/tests/activeBoardServerPersist.spec.ts
@@ -5,6 +5,7 @@ const store: Record<string, any> = {};
 vi.mock('@/state', () => {
   const KS = {
     ACTIVE: (d: string, s: string) => `ACTIVE:${d}:${s}`,
+    DRAFT: (d: string, s: string) => `DRAFT:${d}:${s}`,
   };
   const STATE = {
     dateISO: '2024-01-01',
@@ -21,7 +22,7 @@ vi.mock('@/state', () => {
     CURRENT_SCHEMA_VERSION: 1,
     migrateActiveBoard: (a: any) => a,
     setActiveBoardCache: vi.fn(),
-    getActiveBoardCache: () => undefined,
+    getActiveBoardCache: (_d: string, _s: string) => undefined,
     mergeBoards: (remote: any, local: any) => ({ ...remote, ...local }),
     DB: {
       get: async (k: string) => store[k],

--- a/tests/activeBoardServerPersist.spec.ts
+++ b/tests/activeBoardServerPersist.spec.ts
@@ -21,6 +21,8 @@ vi.mock('@/state', () => {
     CURRENT_SCHEMA_VERSION: 1,
     migrateActiveBoard: (a: any) => a,
     setActiveBoardCache: vi.fn(),
+    getActiveBoardCache: () => undefined,
+    mergeBoards: (remote: any, local: any) => ({ ...remote, ...local }),
     DB: {
       get: async (k: string) => store[k],
       set: async (k: string, v: any) => {

--- a/tests/board.spec.ts
+++ b/tests/board.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('@/state', () => ({
   getConfig: () => ({ showPinned: {} }),
-  getActiveBoardCache: () => undefined,
+  getActiveBoardCache: (_d: string, _s: string) => undefined,
 }));
 
 import { renderLeadership } from '@/ui/board';

--- a/tests/manageOverlayPersist.spec.ts
+++ b/tests/manageOverlayPersist.spec.ts
@@ -37,6 +37,7 @@ vi.mock('@/state', () => {
     migrateActiveBoard: (a: any) => a,
     setActiveBoardCache: () => {},
     getActiveBoardCache: () => store[KS.ACTIVE(STATE.dateISO, STATE.shift)],
+    mergeBoards: (remote: any, local: any) => ({ ...remote, ...local }),
     DB: {
       get: async (k: string) => store[k],
       set: async (k: string, v: any) => { store[k] = v; },

--- a/tests/manageOverlayPersist.spec.ts
+++ b/tests/manageOverlayPersist.spec.ts
@@ -36,7 +36,7 @@ vi.mock('@/state', () => {
     CURRENT_SCHEMA_VERSION: 1,
     migrateActiveBoard: (a: any) => a,
     setActiveBoardCache: () => {},
-    getActiveBoardCache: () => store[KS.ACTIVE(STATE.dateISO, STATE.shift)],
+    getActiveBoardCache: (d: string, s: string) => store[KS.ACTIVE(d, s)],
     mergeBoards: (remote: any, local: any) => ({ ...remote, ...local }),
     DB: {
       get: async (k: string) => store[k],

--- a/tests/saveOnHide.spec.ts
+++ b/tests/saveOnHide.spec.ts
@@ -38,9 +38,11 @@ vi.mock('@/state', () => {
     STATE,
     KS,
     loadStaff,
+    saveStaff: vi.fn(),
     migrateActiveBoard: (a: any) => a,
     setActiveBoardCache: () => {},
     getActiveBoardCache: () => store[KS.ACTIVE(STATE.dateISO, STATE.shift)],
+    mergeBoards: (remote: any, local: any) => ({ ...remote, ...local }),
     DB: {
       get: async (k: string) => store[k],
       set: async (k: string, v: any) => {

--- a/tests/saveOnHide.spec.ts
+++ b/tests/saveOnHide.spec.ts
@@ -41,7 +41,7 @@ vi.mock('@/state', () => {
     saveStaff: vi.fn(),
     migrateActiveBoard: (a: any) => a,
     setActiveBoardCache: () => {},
-    getActiveBoardCache: () => store[KS.ACTIVE(STATE.dateISO, STATE.shift)],
+    getActiveBoardCache: (d: string, s: string) => store[KS.ACTIVE(d, s)],
     mergeBoards: (remote: any, local: any) => ({ ...remote, ...local }),
     DB: {
       get: async (k: string) => store[k],


### PR DESCRIPTION
## Summary
- initialize board view from in-memory cache and merge with server data to keep assignments when switching tabs or reloading
- adjust tests to mock new cache utilities

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be4e5482e88327884ada43e298224b