### PR TITLE
feat(history): show shift times

### DIFF
--- a/src/history/CalendarView.ts
+++ b/src/history/CalendarView.ts
@@ -6,6 +6,7 @@ import {
 } from '@/state/history';
 import { exportShiftCSV } from '@/history';
 import { DB, KS } from '@/state';
+import { formatTime24h, formatDuration } from '@/utils/format';
 import './history.css';
 
 function isPublishedShiftSnapshot(obj: any): obj is PublishedShiftSnapshot {
@@ -58,7 +59,7 @@ export function renderCalendarView(root: HTMLElement): void {
     table.className = 'history-table';
     const thead = document.createElement('thead');
     const headRow = document.createElement('tr');
-    ['Date', 'Shift', 'Name', 'Role', 'Zone'].forEach((h) => {
+    ['Date', 'Shift', 'Name', 'Role', 'Zone', 'Start', 'End', 'Total'].forEach((h) => {
       const th = document.createElement('th');
       th.textContent = h;
       headRow.appendChild(th);
@@ -69,7 +70,10 @@ export function renderCalendarView(root: HTMLElement): void {
     snaps.forEach((s) => {
       s.zoneAssignments.forEach((a) => {
         const tr = document.createElement('tr');
-        [s.dateISO, s.shift, a.displayName, a.role, a.zone].forEach((text) => {
+        const start = formatTime24h(a.startISO);
+        const end = a.endISO ? formatTime24h(a.endISO) : '';
+        const total = a.endISO ? formatDuration(a.startISO, a.endISO) : '';
+        [s.dateISO, s.shift, a.displayName, a.role, a.zone, start, end, total].forEach((text) => {
           const td = document.createElement('td');
           td.textContent = text;
           tr.appendChild(td);

--- a/src/history/NurseHistory.ts
+++ b/src/history/NurseHistory.ts
@@ -1,6 +1,7 @@
 import { loadStaff, type Staff } from '@/state';
 import { findShiftsByStaff } from '@/state/history';
 import { exportNurseHistoryCSV } from '@/history';
+import { formatTime24h, formatDuration } from '@/utils/format';
 import './history.css';
 
 /**
@@ -78,11 +79,13 @@ export function renderNurseHistory(root: HTMLElement): void {
     current = await findShiftsByStaff(id);
     exportBtn.disabled = current.length === 0;
     details.innerHTML = current.length
-      ? `<table class="history-table"><thead><tr><th>Date</th><th>Shift</th><th>Zone</th><th>Prev Zone</th></tr></thead><tbody>${current
-          .map(
-            (r) =>
-              `<tr><td>${r.dateISO}</td><td>${r.shift}</td><td>${r.zone}</td><td>${r.previousZone ?? ''}</td></tr>`
-          )
+      ? `<table class="history-table"><thead><tr><th>Date</th><th>Shift</th><th>Zone</th><th>Prev Zone</th><th>Start</th><th>End</th><th>Total</th></tr></thead><tbody>${current
+          .map((r) => {
+            const start = formatTime24h(r.startISO);
+            const end = r.endISO ? formatTime24h(r.endISO) : '';
+            const total = r.endISO ? formatDuration(r.startISO, r.endISO) : '';
+            return `<tr><td>${r.dateISO}</td><td>${r.shift}</td><td>${r.zone}</td><td>${r.previousZone ?? ''}</td><td>${start}</td><td>${end}</td><td>${total}</td></tr>`;
+          })
           .join('')}</tbody></table>`
       : '<div class="muted">No history found</div>';
   }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -24,3 +24,19 @@ export function formatTime24h(d: Date | string | number) {
     minute: '2-digit',
   }).format(new Date(d));
 }
+
+/**
+ * Format duration between two ISO timestamps as H:MM.
+ * @param startISO start ISO timestamp
+ * @param endISO end ISO timestamp
+ * @returns formatted duration or empty string if invalid
+ */
+export function formatDuration(startISO: string, endISO: string): string {
+  const start = new Date(startISO).getTime();
+  const end = new Date(endISO).getTime();
+  if (!isFinite(start) || !isFinite(end) || end <= start) return '';
+  const minutes = Math.round((end - start) / 60000);
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return `${hours}:${String(mins).padStart(2, '0')}`;
+}

--- a/tests/format.spec.ts
+++ b/tests/format.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { formatDuration } from '@/utils/format';
+
+describe('formatDuration', () => {
+  it('formats positive durations', () => {
+    const start = '2024-01-01T07:00:00.000Z';
+    const end = '2024-01-01T08:30:00.000Z';
+    expect(formatDuration(start, end)).toBe('1:30');
+  });
+
+  it('returns empty string for invalid ranges', () => {
+    const start = '2024-01-01T07:00:00.000Z';
+    expect(formatDuration(start, start)).toBe('');
+    expect(formatDuration(start, 'bad')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- show start, end, and total time for each shift in history views
- provide formatting helper for ISO duration
- add tests for duration formatting

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bee291b1308327bef5f8e78ab08995