### PR TITLE
Improve board layout layering and manage dialog

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -206,7 +206,7 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .flags-panel li{padding:4px 0}
 
 .manage-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:var(--z-modal)}
-.manage-dialog{background:var(--panel);padding:16px;border-radius:8px;display:flex;flex-direction:column;gap:8px;min-width:260px}
+.manage-dialog{background:var(--panel);padding:16px;border-radius:8px;display:flex;flex-direction:column;gap:8px;min-width:340px}
 .manage-dialog label{display:flex;flex-direction:column;gap:4px}
 .manage-dialog .dialog-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:8px}
 .assign-dialog{min-width:400px}

--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -449,6 +449,7 @@ function renderZones(
     const editBtn = document.createElement('button');
     editBtn.textContent = '⚙';
     editBtn.className = 'zone-card__edit';
+    editBtn.title = 'Edit zone';
     editBtn.addEventListener('click', async () => {
       const val = prompt('Rename zone', z.name)?.trim();
       if (val && val !== z.name) {
@@ -532,6 +533,7 @@ function renderZones(
     addBtn.className = hasSlots
       ? 'zone-card__add zone-card__add--small'
       : 'zone-card__add zone-card__add--large';
+    addBtn.title = 'Add staff';
     addBtn.addEventListener('click', () => {
       openAssignDialog(staff, (id) => {
         const moved = upsertSlot(active, { zone: z.name }, { nurseId: id });
@@ -765,6 +767,8 @@ function manageSlot(
       <h3>Manage ${st.name || labelFromId(st.id)}</h3>
       <label>Name <input id="mg-name" value="${st.name || ''}"></label>
       <label>RF <input id="mg-rf" type="number" value="${st.rf ?? ''}"></label>
+      <label>End time <input id="mg-end" type="time" value="${endValue}"></label>
+      <label>Comment <input id="mg-comment" placeholder="Add comment" value="${slot.comment || ''}"></label>
       <label>Role <select id="mg-role">
         <option value="nurse"${currentRole === 'nurse' ? ' selected' : ''}>Nurse</option>
         <option value="tech"${currentRole === 'tech' ? ' selected' : ''}>Tech</option>
@@ -780,10 +784,8 @@ function manageSlot(
         </select></label>
       </div>
       <label>Student <input id="mg-student" value="${typeof slot.student === 'string' ? slot.student : ''}"></label>
-      <label>Comment <input id="mg-comment" value="${slot.comment || ''}"></label>
       <label><input type="checkbox" id="mg-break" ${slot.break?.active ? 'checked' : ''}/> On break</label>
       <label><input type="checkbox" id="mg-bad" ${slot.bad ? 'checked' : ''}/> Bad</label>
-      <label>End time <input id="mg-end" type="time" value="${endValue}"></label>
       <label>Zone <select id="mg-zone">
         ${(cfg.zones || [])
           .map((z: ZoneDef) => `<option value="${z.name}"${z.name === zone ? ' selected' : ''}>${z.name}</option>`)

--- a/src/ui/mainBoard/boardLayout.css
+++ b/src/ui/mainBoard/boardLayout.css
@@ -57,6 +57,8 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  position: relative;
+  z-index: 1;
 }
 
 .nurse-card__text {

--- a/src/ui/nurseTile.ts
+++ b/src/ui/nurseTile.ts
@@ -4,21 +4,22 @@ import { getConfig } from '@/state/config';
 import { getActiveBoardCache, STATE } from '@/state';
 import { formatName } from '@/utils/names';
 
+/** Render a nurse tile with status icons. */
 export function nurseTile(slot: Slot, staff: Staff): string {
   const chips: string[] = [];
   if (slot.break?.active) {
     chips.push(
-      `<span class="chip" aria-label="On break"><span class="icon">☕</span></span>`
+      `<span class="chip" aria-label="On break" title="On break"><span class="icon">☕</span></span>`
     );
   }
   if (slot.student) {
     chips.push(
-      `<span class="chip" aria-label="Has student"><span class="icon">🎓</span></span>`
+      `<span class="chip" aria-label="Has student" title="Has student"><span class="icon">🎓</span></span>`
     );
   }
   if (slot.bad) {
     chips.push(
-      `<span class="chip" aria-label="Marked bad"><span class="icon">⚠️</span></span>`
+      `<span class="chip" aria-label="Marked bad" title="Marked bad"><span class="icon">⚠️</span></span>`
     );
   }
 
@@ -39,7 +40,7 @@ export function nurseTile(slot: Slot, staff: Staff): string {
     const msLeft = new Date(endISO).getTime() - Date.now();
     if (msLeft > 0 && msLeft <= 60 * 60 * 1000) {
       chips.push(
-        `<span class="chip" aria-label="Shift ending soon"><span class="icon">🚪</span></span>`
+        `<span class="chip" aria-label="Shift ending soon" title="Shift ending soon"><span class="icon">🚪</span></span>`
       );
     }
   }

--- a/tests/slots.spec.ts
+++ b/tests/slots.spec.ts
@@ -106,7 +106,7 @@ describe("nurse tile snapshot", () => {
       type: "other",
     });
     expect(html).toMatchInlineSnapshot(
-      `"<div class=\"nurse-card\" data-type=\"other\" data-role=\"nurse\" tabindex=\"0\" aria-label=\"Alice, other nurse, comment note, on break, has student, marked bad\"><div class=\"nurse-card__text\"><div class=\"nurse-card__name\">Alice</div><div class=\"nurse-card__meta\">other nurse</div><div class=\"nurse-card__comment\"><span class=\"icon\">💬</span> note</div></div><span class=\"chips\"><span class=\"chip\" aria-label=\"On break\"><span class=\"icon\">☕</span></span><span class=\"chip\" aria-label=\"Has student\"><span class=\"icon\">🎓</span></span><span class=\"chip\" aria-label=\"Marked bad\"><span class=\"icon\">⚠️</span></span></span></div>"`
+      `"<div class=\"nurse-card\" data-type=\"other\" data-role=\"nurse\" tabindex=\"0\" aria-label=\"Alice, other nurse, comment note, on break, has student, marked bad\"><div class=\"nurse-card__text\"><div class=\"nurse-card__name\">Alice</div><div class=\"nurse-card__meta\">other nurse</div><div class=\"nurse-card__comment\"><span class=\"icon\">💬</span> note</div></div><span class=\"chips\"><span class=\"chip\" aria-label=\"On break\" title=\"On break\"><span class=\"icon\">☕</span></span><span class=\"chip\" aria-label=\"Has student\" title=\"Has student\"><span class=\"icon\">🎓</span></span><span class=\"chip\" aria-label=\"Marked bad\" title=\"Marked bad\"><span class=\"icon\">⚠️</span></span></span></div>"`
     );
   });
 });


### PR DESCRIPTION
## Summary
- prevent nurse cards from being obscured by neighboring zones
- expand manage dialog and prioritize end time and comment fields
- add descriptive tooltips for zone buttons and nurse status icons

## Testing
- `npm test` *(fails: ECONNREFUSED connection errors in physiciansDom.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1eb7c9a883278179ae8aa47a9f98