### PR TITLE
Add zone clear button for next shift assignments

### DIFF
--- a/src/ui/nextShift/NextShiftPage.ts
+++ b/src/ui/nextShift/NextShiftPage.ts
@@ -72,9 +72,9 @@ export async function renderNextShiftPage(root: HTMLElement): Promise<void> {
       const name = slot
         ? staff.find((s) => s.id === slot.nurseId)?.name || slot.nurseId
         : '';
-      return `<tr><td>${z.name}</td><td><div id="zone-${z.id}" class="zone-drop" data-zone="${z.name}" ${
+      return `<tr><td>${z.name}</td><td class="zone-cell"><div id="zone-${z.id}" class="zone-drop" data-zone="${z.name}" ${
         slot ? `data-nurse-id="${slot.nurseId}"` : ''
-      }>${name}</div></td></tr>`;
+      }>${name}</div><button class="btn zone-clear" data-zone-id="${z.id}">Clear</button></td></tr>`;
     })
     .join('');
 
@@ -174,6 +174,17 @@ export async function renderNextShiftPage(root: HTMLElement): Promise<void> {
         const s = staff.find((st) => st.id === id);
         (el as HTMLElement).textContent = s?.name || id;
         (el as HTMLElement).dataset.nurseId = id;
+      }
+    });
+  });
+
+  root.querySelectorAll('.zone-clear').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const id = (btn as HTMLElement).dataset.zoneId;
+      const zone = document.getElementById(`zone-${id}`) as HTMLElement | null;
+      if (zone) {
+        zone.textContent = '';
+        delete zone.dataset.nurseId;
       }
     });
   });

--- a/src/ui/nextShift/__tests__/NextShiftPage.test.ts
+++ b/src/ui/nextShift/__tests__/NextShiftPage.test.ts
@@ -89,6 +89,21 @@ describe('renderNextShiftPage', () => {
     expect(publishNextDraft).toHaveBeenCalled();
   });
 
+  it('clears a zone when delete is clicked', async () => {
+    vi.setSystemTime(new Date('2024-01-01T08:00:00'));
+    const root = document.getElementById('root') as HTMLElement;
+    await renderNextShiftPage(root);
+
+    const zone = root.querySelector('#zone-a') as HTMLElement;
+    zone.textContent = 'Alice';
+    zone.dataset.nurseId = 'n1';
+
+    (root.querySelector('.zone-clear[data-zone-id="a"]') as HTMLButtonElement).click();
+
+    expect(zone.textContent).toBe('');
+    expect(zone.dataset.nurseId).toBeUndefined();
+  });
+
   it('filters staff list', async () => {
     vi.setSystemTime(new Date('2024-01-01T08:00:00'));
     const root = document.getElementById('root') as HTMLElement;

--- a/src/ui/nextShift/nextShift.css
+++ b/src/ui/nextShift/nextShift.css
@@ -48,3 +48,17 @@
   background: rgba(74, 163, 255, 0.15);
   border-radius: 8px;
 }
+
+.next-shift .zone-cell {
+  display: flex;
+  align-items: center;
+  gap: var(--gap);
+}
+
+.next-shift .zone-cell .zone-drop {
+  flex: 1;
+}
+
+.next-shift .zone-clear {
+  padding: 0.25rem 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add Clear button to each zone on the Next Shift page
- style zone cells for button layout
- test that zone assignments can be removed

## Testing
- `npm test` (fails: tests/physiciansDom.spec.ts)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3f2f8e7488327bc1b896fcb112763