### PR TITLE
Disable Grammarly in comments textarea

### DIFF
--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -148,7 +148,12 @@ export async function renderBoard(
 
           <section class="panel">
             <h3>Comments</h3>
-            <textarea id="comments" class="input" placeholder="Current Status..."></textarea>
+            <textarea
+              id="comments"
+              class="input"
+              placeholder="Current Status..."
+              data-gramm="false"
+            ></textarea>
           </section>
         </div>
 


### PR DESCRIPTION
## Summary
- prevent Grammarly extension from injecting into the board comments box by disabling it via `data-gramm="false"`

## Testing
- `npm test tests/physiciansDom.spec.ts` (fails: physician schedule rendering tests)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c24046fb78832792ed62be70ff8210