### PR TITLE
Revamp staff manage menu with high acuity tracking and RF display

### DIFF
--- a/src/slots.ts
+++ b/src/slots.ts
@@ -5,7 +5,7 @@ export type Slot = {
   startHHMM?: string;
   student?: string | boolean;
   comment?: string;
-  bad?: boolean;
+  highAcuityUntil?: number;
   break?: {
     active: boolean;
     startISO?: string;

--- a/src/styles.css
+++ b/src/styles.css
@@ -209,6 +209,13 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .manage-dialog{background:var(--panel);padding:16px;border-radius:8px;display:flex;flex-direction:column;gap:8px;min-width:340px}
 .manage-dialog label{display:flex;flex-direction:column;gap:4px}
 .manage-dialog .dialog-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:8px}
+.manage-header{display:flex;flex-direction:column;gap:4px;margin-bottom:8px}
+.role-chip{align-self:flex-start;padding:2px 6px;border:1px solid var(--card-border);border-radius:4px;font-weight:600}
+.staff-type{color:var(--text-med);font-size:.85em}
+.manage-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+.manage-col{display:flex;flex-direction:column;gap:8px}
+.manage-col label.mod{flex-direction:row;align-items:center}
+.manage-col label.mod .icon{margin-right:4px}
 .assign-dialog{min-width:400px}
 .assign-cols{display:flex;gap:8px}
 .assign-col{flex:1;max-height:200px;overflow-y:auto;border:1px solid var(--card-border);border-radius:4px;}

--- a/src/ui/mainBoard/boardLayout.css
+++ b/src/ui/mainBoard/boardLayout.css
@@ -86,6 +86,12 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  display: flex;
+  justify-content: space-between;
+}
+
+.nurse-card__rf {
+  margin-left: 8px;
 }
 
 .nurse-card__comment {

--- a/src/ui/nurseTile.ts
+++ b/src/ui/nurseTile.ts
@@ -17,9 +17,9 @@ export function nurseTile(slot: Slot, staff: Staff): string {
       `<span class="chip" aria-label="Has student" title="Has student"><span class="icon">🎓</span></span>`
     );
   }
-  if (slot.bad) {
+  if (slot.highAcuityUntil && slot.highAcuityUntil > Date.now()) {
     chips.push(
-      `<span class="chip" aria-label="Marked bad" title="Marked bad"><span class="icon">⚠️</span></span>`
+      `<span class="chip" aria-label="Recovering from high acuity" title="Recovering from high acuity"><span class="icon">🔥</span></span>`
     );
   }
 
@@ -66,7 +66,7 @@ export function nurseTile(slot: Slot, staff: Staff): string {
   const statuses: string[] = [];
   if (slot.break?.active) statuses.push('on break');
   if (slot.student) statuses.push('has student');
-  if (slot.bad) statuses.push('marked bad');
+  if (slot.highAcuityUntil && slot.highAcuityUntil > Date.now()) statuses.push('recovering from high acuity');
 
   const aria =
     `${name}` +
@@ -79,5 +79,9 @@ export function nurseTile(slot: Slot, staff: Staff): string {
     ? `<div class="nurse-card__comment"><span class="icon">💬</span> ${slot.comment}</div>`
     : '';
 
-  return `<div class="nurse-card" data-type="${staff.type ?? 'other'}" data-role="${staff.role ?? 'nurse'}" tabindex="0" aria-label="${aria}"><div class="nurse-card__text"><div class="nurse-card__name">${name}</div><div class="nurse-card__meta">${meta}</div>${commentHtml}</div>${chipStr}</div>`;
+  const metaHtml = staff.rf
+    ? `<div class="nurse-card__meta"><span>${meta}</span><span class="nurse-card__rf">${staff.rf}</span></div>`
+    : `<div class="nurse-card__meta">${meta}</div>`;
+
+  return `<div class="nurse-card" data-type="${staff.type ?? 'other'}" data-role="${staff.role ?? 'nurse'}" tabindex="0" aria-label="${aria}"><div class="nurse-card__text"><div class="nurse-card__name">${name}</div>${metaHtml}${commentHtml}</div>${chipStr}</div>`;
 }

--- a/tests/slots.spec.ts
+++ b/tests/slots.spec.ts
@@ -96,17 +96,17 @@ describe("nurse tile snapshot", () => {
         relievedBy: { rf: "552" },
       },
       endTimeOverrideHHMM: "13:00",
-      dto: true,
-      bad: true,
+      highAcuityUntil: Date.now() + 60 * 60 * 1000,
     };
     const html = renderTile(slot, {
       id: "1",
       name: "Alice",
       role: "nurse",
       type: "other",
+      rf: 123,
     });
     expect(html).toMatchInlineSnapshot(
-      `"<div class=\"nurse-card\" data-type=\"other\" data-role=\"nurse\" tabindex=\"0\" aria-label=\"Alice, other nurse, comment note, on break, has student, marked bad\"><div class=\"nurse-card__text\"><div class=\"nurse-card__name\">Alice</div><div class=\"nurse-card__meta\">other nurse</div><div class=\"nurse-card__comment\"><span class=\"icon\">💬</span> note</div></div><span class=\"chips\"><span class=\"chip\" aria-label=\"On break\" title=\"On break\"><span class=\"icon\">☕</span></span><span class=\"chip\" aria-label=\"Has student\" title=\"Has student\"><span class=\"icon\">🎓</span></span><span class=\"chip\" aria-label=\"Marked bad\" title=\"Marked bad\"><span class=\"icon\">⚠️</span></span></span></div>"`
+      `"<div class=\"nurse-card\" data-type=\"other\" data-role=\"nurse\" tabindex=\"0\" aria-label=\"Alice, other nurse, comment note, on break, has student, recovering from high acuity\"><div class=\"nurse-card__text\"><div class=\"nurse-card__name\">Alice</div><div class=\"nurse-card__meta\"><span>other nurse</span><span class=\"nurse-card__rf\">123</span></div><div class=\"nurse-card__comment\"><span class=\"icon\">💬</span> note</div></div><span class=\"chips\"><span class=\"chip\" aria-label=\"On break\" title=\"On break\"><span class=\"icon\">☕</span></span><span class=\"chip\" aria-label=\"Has student\" title=\"Has student\"><span class=\"icon\">🎓</span></span><span class=\"chip\" aria-label=\"Recovering from high acuity\" title=\"Recovering from high acuity\"><span class=\"icon\">🔥</span></span></span></div>"`
     );
   });
 });


### PR DESCRIPTION
## Summary
- Rework staff manage dialog: show role/type header, start & end times, RF field, and icons for student, break, and high acuity
- Track high-acuity recovery state for two hours and display corresponding icon on staff tiles
- Display RF numbers on nurse tiles and adjust styling

## Testing
- `npm test` *(fails: connect ECONNREFUSED ::1:3000; FAIL tests/physiciansDom.spec.ts)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf282c85b48327b76963bf1090d89b