### PR TITLE
Use 'ping' action for API health check

### DIFF
--- a/src/server/adapter.ts
+++ b/src/server/adapter.ts
@@ -32,7 +32,7 @@ const withAuth = (headers: HeadersInit = {}): HeadersInit => (
 
 export const health: ServerAPI['health'] = async () => {
   try {
-    const res = await fetch('/api.php?action=health', {
+    const res = await fetch('/api.php?action=ping', {
       cache: 'no-store',
       headers: withAuth(),
     });

--- a/tests/api-auth.spec.ts
+++ b/tests/api-auth.spec.ts
@@ -37,5 +37,14 @@ describe('API auth', () => {
     await new Promise((r) => setTimeout(r, 50));
     expect(logs).toContain('unauthorized');
   });
+
+  it('accepts correct key', async () => {
+    const res = await fetch('http://127.0.0.1:8020/api.php?action=ping', {
+      headers: { 'X-API-Key': 'test-key' },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
 });
 


### PR DESCRIPTION
## Summary
- Align server adapter with `action=ping` health endpoint
- Verify API key accepted and health check responds successfully

## Testing
- `npm test`
- `npm run build`
- `curl -i -H 'X-API-Key: test-key' http://127.0.0.1:8020/api.php?action=ping`


------
https://chatgpt.com/codex/tasks/task_e_68c7825dd5148327940610831a8f3de8