### PR TITLE
Run tests in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,27 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install
+        run: npm ci
+      - name: Test
+        run: npm test
+
   build:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- ensure build workflow runs `npm test` before `npm run build`
- split workflow into test and build jobs so builds depend on passing tests
- trigger workflow on push and pull_request events

## Testing
- `npm test` *(fails: connect ECONNREFUSED ::1:3000)*

------
https://chatgpt.com/codex/tasks/task_e_68c782672e7883279c9476161bcc9b34