### PR TITLE
docs: add env example and setup guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Example environment variables for StaffBoard.
+# Copy this file to .env and fill in required values.
+
+# API key used by the web client for authenticated requests.
+VITE_API_KEY=
+
+# PHP API configuration (optional)
+HEYBRE_API_KEY=
+HEYBRE_DATA_DIR=
+HEYBRE_DB_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .DS_Store
 dist
+.env
 
 
 *.zip

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ for the UI.
 - Install dependencies: `npm ci`
 - Diagnostics: visit `/diag.html`
 
+## Setup
+
+- Copy `.env.example` to `.env` and fill in required values.
+- `VITE_API_KEY` must match the key expected by the PHP API.
+
+### Production
+
+Supply `VITE_API_KEY` via CI secrets (e.g., GitHub Actions) or your host's
+environment variable settings (Netlify, Vercel, etc.) rather than committing
+it to source control.
+
 ## Roster management
 
 The Settings tab includes an editable staff roster with JSON import/export for nurses, techs, sitters, ancillary staff, and administrators.


### PR DESCRIPTION
## Summary
- ignore local `.env`
- provide `.env.example` with `VITE_API_KEY` and server vars
- document environment setup and production secrets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7826290748327aae8780f66f777af