### PR TITLE
Enable exact optional property types

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
   DB,
   KS,
   mergeBoards,
+  type ActiveBoard,
 } from '@/state';
 import { applyTheme } from '@/state/theme';
 import { applyUI } from '@/state/uiConfig';
@@ -104,7 +105,7 @@ initState();
     const { dateISO, shift } = STATE;
     try {
       const remote = await Server.load('active', { date: dateISO, shift });
-      const local = await DB.get(KS.ACTIVE(dateISO, shift));
+      const local = await DB.get<ActiveBoard>(KS.ACTIVE(dateISO, shift));
       if (remote) {
         const merged = local ? mergeBoards(remote, local) : remote;
         if (JSON.stringify(merged) !== JSON.stringify(local)) {

--- a/src/slots.ts
+++ b/src/slots.ts
@@ -2,25 +2,25 @@
 export type Slot = {
   nurseId: string;
   /** Optional scheduled start time in HH:MM */
-  startHHMM?: string;
-  student?: string | boolean;
-  comment?: string;
-  highAcuityUntil?: number;
+  startHHMM?: string | undefined;
+  student?: string | boolean | undefined;
+  comment?: string | undefined;
+  highAcuityUntil?: number | undefined;
   break?: {
     active: boolean;
-    startISO?: string;
-    plannedEndHHMM?: string;
-    relievedBy?: { id?: string; rf?: string; name?: string };
-  };
-  endTimeOverrideHHMM?: string;
-  dto?: boolean;
-  assignedTs?: number;
+    startISO?: string | undefined;
+    plannedEndHHMM?: string | undefined;
+    relievedBy?: { id?: string; rf?: string; name?: string } | undefined;
+  } | undefined;
+  endTimeOverrideHHMM?: string | undefined;
+  dto?: boolean | undefined;
+  assignedTs?: number | undefined;
 };
 
 export interface Board {
-  charge?: Slot;
-  triage?: Slot;
-  admin?: Slot;
+  charge?: Slot | undefined;
+  triage?: Slot | undefined;
+  admin?: Slot | undefined;
   zones: Record<string, Slot[]>;
 }
 
@@ -86,15 +86,21 @@ export function removeSlot(
   target: "charge" | "triage" | "admin" | { zone: string; index: number }
 ): boolean {
   let removed = false;
-  if (target === "charge" && board.charge) {
-    board.charge = undefined;
-    removed = true;
-  } else if (target === "triage" && board.triage) {
-    board.triage = undefined;
-    removed = true;
-  } else if (target === "admin" && board.admin) {
-    board.admin = undefined;
-    removed = true;
+  if (target === "charge") {
+    if (board.charge) {
+      board.charge = undefined;
+      removed = true;
+    }
+  } else if (target === "triage") {
+    if (board.triage) {
+      board.triage = undefined;
+      removed = true;
+    }
+  } else if (target === "admin") {
+    if (board.admin) {
+      board.admin = undefined;
+      removed = true;
+    }
   } else {
     const arr = board.zones[target.zone];
     if (arr && arr.splice(target.index, 1).length) removed = true;

--- a/src/state/config.ts
+++ b/src/state/config.ts
@@ -8,11 +8,11 @@ import { KS } from './keys';
 import { STATE } from './index';
 
 export type WidgetsConfig = {
-  show?: boolean;
+  show?: boolean | undefined;
   weather: {
     units: 'F' | 'C';
-    lat?: number;
-    lon?: number;
+    lat?: number | undefined;
+    lon?: number | undefined;
   };
 };
 
@@ -23,20 +23,20 @@ export type Config = {
   pin: string;
   relockMin: number;
   widgets: WidgetsConfig;
-  zoneColors?: Record<string, string>;
-  shiftDurations?: { day: number; night: number };
-  dtoMinutes?: number;
-  showPinned?: { charge: boolean; triage: boolean };
-  rss?: { url: string; enabled: boolean };
-  physicians?: { calendarUrl: string };
-  privacy?: boolean;
+  zoneColors?: Record<string, string> | undefined;
+  shiftDurations?: { day: number; night: number } | undefined;
+  dtoMinutes?: number | undefined;
+  showPinned?: { charge: boolean; triage: boolean } | undefined;
+  rss?: { url: string; enabled: boolean } | undefined;
+  physicians?: { calendarUrl: string } | undefined;
+  privacy?: boolean | undefined;
   ui?: {
     signoutMode?: 'shiftHuddle' | 'disabled' | 'legacySignout';
-    rightSidebarWidthPx?: number;
-    rightSidebarMinPx?: number;
-    rightSidebarMaxPx?: number;
-  };
-  uiTheme?: UIThemeConfig;
+    rightSidebarWidthPx?: number | undefined;
+    rightSidebarMinPx?: number | undefined;
+    rightSidebarMaxPx?: number | undefined;
+  } | undefined;
+  uiTheme?: UIThemeConfig | undefined;
 };
 
 export const WIDGETS_DEFAULTS: WidgetsConfig = {

--- a/src/state/handoff.ts
+++ b/src/state/handoff.ts
@@ -9,7 +9,7 @@ import {
 import { generateShiftCode, nextShiftWindow, ShiftSchedule } from '@/utils/shiftCodes';
 
 export type HandoffState = {
-  active?: Handoff;
+  active?: Handoff | undefined;
   begin(): Promise<void>;
   saveUpdates(patch: Partial<Handoff['updates']>): Promise<void>;
   startInPerson(seconds: number): Promise<void>;

--- a/src/state/history.ts
+++ b/src/state/history.ts
@@ -117,11 +117,11 @@ export interface Assignment {
   role: RoleKind;
   zone: string;
   startISO: string;
-  endISO?: string;
+  endISO?: string | undefined;
   dto?: {
     effectiveISO: string;
     offgoingUntilISO: string;
-  };
+  } | undefined;
 }
 
 export interface HuddleChecklistItem {
@@ -149,20 +149,20 @@ export interface PublishedShiftSnapshot {
   shift: ShiftKind;
   publishedAtISO: string;
   publishedBy: string;
-  charge?: string;
-  triage?: string;
-  admin?: string;
+  charge?: string | undefined;
+  triage?: string | undefined;
+  admin?: string | undefined;
   zoneAssignments: Assignment[];
   incoming: string[];
   offgoing: string[];
   comments: string;
-  huddle?: HuddleRecord;
+  huddle?: HuddleRecord | undefined;
   audit: {
     createdAtISO: string;
     createdBy: string;
-    mutatedAtISO?: string;
-    mutatedBy?: string;
-    reason?: string;
+    mutatedAtISO?: string | undefined;
+    mutatedBy?: string | undefined;
+    reason?: string | undefined;
   };
 }
 
@@ -173,10 +173,10 @@ export interface NurseShiftIndexEntry {
   dateISO: string;
   shift: ShiftKind;
   zone: string;
-  previousZone?: string;
+  previousZone?: string | undefined;
   startISO: string;
-  endISO?: string;
-  dto?: boolean;
+  endISO?: string | undefined;
+  dto?: boolean | undefined;
 }
 
 export interface HistoryDB {

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -20,11 +20,11 @@ import type { UIThemeConfig } from '@/state/theme';
 import { THEME_PRESETS } from '@/state/theme';
 
 export type WidgetsConfig = {
-  show?: boolean;
+  show?: boolean | undefined;
   weather: {
     units: 'F' | 'C';
-    lat?: number;
-    lon?: number;
+    lat?: number | undefined;
+    lon?: number | undefined;
   };
 };
 
@@ -35,37 +35,37 @@ export type Config = {
   pin: string;
   relockMin: number;
   widgets: WidgetsConfig;
-  zoneColors?: Record<string, string>;
-  shiftDurations?: { day: number; night: number };
-  dtoMinutes?: number;
-  showPinned?: { charge: boolean; triage: boolean };
-  rss?: { url: string; enabled: boolean };
-  physicians?: { calendarUrl: string };
-  privacy?: boolean;
+  zoneColors?: Record<string, string> | undefined;
+  shiftDurations?: { day: number; night: number } | undefined;
+  dtoMinutes?: number | undefined;
+  showPinned?: { charge: boolean; triage: boolean } | undefined;
+  rss?: { url: string; enabled: boolean } | undefined;
+  physicians?: { calendarUrl: string } | undefined;
+  privacy?: boolean | undefined;
   ui?: {
     signoutMode?: 'shiftHuddle' | 'disabled' | 'legacySignout';
-    rightSidebarWidthPx?: number;
-    rightSidebarMinPx?: number;
-    rightSidebarMaxPx?: number;
-  };
-  uiTheme?: UIThemeConfig;
+    rightSidebarWidthPx?: number | undefined;
+    rightSidebarMinPx?: number | undefined;
+    rightSidebarMaxPx?: number | undefined;
+  } | undefined;
+  uiTheme?: UIThemeConfig | undefined;
 };
 
 export type Staff = {
   id: string;
-  name?: string;
-  first?: string;
-  last?: string;
-  rf?: number;
+  name?: string | undefined;
+  first?: string | undefined;
+  last?: string | undefined;
+  rf?: number | undefined;
   role: 'nurse' | 'tech';
   type: NurseType;
-  active?: boolean;
-  notes?: string;
-  prefDay?: boolean;
-  prefNight?: boolean;
-  eligibleRoles?: ('charge' | 'triage' | 'admin')[];
-  defaultZone?: string;
-  dtoEligible?: boolean;
+  active?: boolean | undefined;
+  notes?: string | undefined;
+  prefDay?: boolean | undefined;
+  prefNight?: boolean | undefined;
+  eligibleRoles?: ('charge' | 'triage' | 'admin')[] | undefined;
+  defaultZone?: string | undefined;
+  dtoEligible?: boolean | undefined;
 };
 
 import { ensureUniqueAssignment, type Slot } from '@/slots';
@@ -74,8 +74,8 @@ export type { Slot } from '@/slots';
 export interface ZoneAssignment {
   id: string;
   role: 'nurse' | 'tech';
-  start?: string;
-  end?: string;
+  start?: string | undefined;
+  end?: string | undefined;
 }
 
 export const CURRENT_SCHEMA_VERSION = 2;
@@ -83,12 +83,12 @@ export const CURRENT_SCHEMA_VERSION = 2;
 export interface ActiveShift {
   dateISO: string;
   shift: Shift;
-  endAtISO?: string;
-  charge?: Slot;
-  triage?: Slot;
-  admin?: Slot;
+  endAtISO?: string | undefined;
+  charge?: Slot | undefined;
+  triage?: Slot | undefined;
+  admin?: Slot | undefined;
   zones: Record<string, Slot[]>;
-  incoming: { nurseId: string; eta: string; arrived?: boolean }[];
+  incoming: { nurseId: string; eta: string; arrived?: boolean | undefined }[];
   offgoing: { nurseId: string; ts: number }[];
   comments: string;
   huddle: string;

--- a/src/state/nextShift.ts
+++ b/src/state/nextShift.ts
@@ -9,8 +9,8 @@ import * as Server from '@/server';
 import { type ZoneDef } from '@/utils/zones';
 
 export interface DraftShift extends BaseDraftShift {
-  publishAtISO?: string;
-  endAtISO?: string;
+  publishAtISO?: string | undefined;
+  endAtISO?: string | undefined;
 }
 
 /** Build an empty draft with zones populated but no assignments. */
@@ -99,5 +99,3 @@ export async function publishNextDraft(opts?: { appendHistory?: boolean }): Prom
   await DB.set(KS.DRAFT(draft.dateISO, draft.shift), draft);
   await applyDraftToActive(draft.dateISO, draft.shift);
 }
-
-export type { DraftShift };

--- a/src/state/staff.ts
+++ b/src/state/staff.ts
@@ -7,19 +7,19 @@ import * as Server from '@/server';
 
 export type Staff = {
   id: string;
-  name?: string;
-  first?: string;
-  last?: string;
-  rf?: number;
+  name?: string | undefined;
+  first?: string | undefined;
+  last?: string | undefined;
+  rf?: number | undefined;
   role: 'nurse' | 'tech';
   type: NurseType;
-  active?: boolean;
-  notes?: string;
-  prefDay?: boolean;
-  prefNight?: boolean;
-  eligibleRoles?: ('charge' | 'triage' | 'admin')[];
-  defaultZone?: string;
-  dtoEligible?: boolean;
+  active?: boolean | undefined;
+  notes?: string | undefined;
+  prefDay?: boolean | undefined;
+  prefNight?: boolean | undefined;
+  eligibleRoles?: ('charge' | 'triage' | 'admin')[] | undefined;
+  defaultZone?: string | undefined;
+  dtoEligible?: boolean | undefined;
 };
 
 /** Load staff roster from server or local DB */

--- a/src/state/theme.ts
+++ b/src/state/theme.ts
@@ -33,11 +33,11 @@ export interface UIThemeConfig {
   scale: number;
   lightPreset: string;
   darkPreset: string;
-  custom?: Partial<ThemeTokens>;
-  highContrast?: boolean;
-  compact?: boolean;
-  iconSize?: number;
-  commentSize?: number;
+  custom?: Partial<ThemeTokens> | undefined;
+  highContrast?: boolean | undefined;
+  compact?: boolean | undefined;
+  iconSize?: number | undefined;
+  commentSize?: number | undefined;
 }
 
 /** Available light and dark presets. */

--- a/src/ui/nextShift/NextShiftPage.ts
+++ b/src/ui/nextShift/NextShiftPage.ts
@@ -156,9 +156,9 @@ export async function renderNextShiftPage(root: HTMLElement): Promise<void> {
           item.classList.toggle('selected', (item as HTMLElement).dataset.id === id);
         });
       });
-      el.addEventListener('dragstart', (ev) => {
-        ev.dataTransfer?.setData('text/plain', id);
-      });
+        (el as HTMLElement).addEventListener('dragstart', (ev) => {
+          (ev as DragEvent).dataTransfer?.setData('text/plain', id);
+        });
     });
   }
 
@@ -166,10 +166,11 @@ export async function renderNextShiftPage(root: HTMLElement): Promise<void> {
   searchInput.addEventListener('input', () => renderStaff(searchInput.value));
 
   root.querySelectorAll('.zone-drop').forEach((el) => {
-    el.addEventListener('dragover', (e) => e.preventDefault());
-    el.addEventListener('drop', (e) => {
-      e.preventDefault();
-      const id = e.dataTransfer?.getData('text/plain');
+      (el as HTMLElement).addEventListener('dragover', (e) => e.preventDefault());
+      (el as HTMLElement).addEventListener('drop', (e) => {
+        const ev = e as DragEvent;
+        ev.preventDefault();
+        const id = ev.dataTransfer?.getData('text/plain');
       if (id) {
         const s = staff.find((st) => st.id === id);
         (el as HTMLElement).textContent = s?.name || id;

--- a/src/utils/zones.ts
+++ b/src/utils/zones.ts
@@ -1,9 +1,9 @@
 export interface ZoneDef {
   id: string;
   name: string;
-  color?: string;
+  color?: string | undefined;
   /** Whether the zone is part of the patient care team area. */
-  pct?: boolean;
+  pct?: boolean | undefined;
 }
 
 function toSlugId(raw: string, fallback: string): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,9 @@
     "moduleResolution": "Bundler",
     "strict": true,
     "resolveJsonModule": true,
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "exactOptionalPropertyTypes": true,
+    "lib": ["ES2021", "DOM"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- enable `exactOptionalPropertyTypes` in TypeScript configuration
- adjust types and helpers to handle explicit `undefined` for optional fields
- clean up event handlers and board utilities to satisfy stricter type checks

## Testing
- `npm run precheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7826d35b48327927d0a6d22d62c6e