### PR TITLE
Add hash-based routing for tabs with accessibility improvements

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ import { seedDefaults } from '@/seedDefaults';
 import { seedDemoHistory } from '@/history/seed';
 import { hhmmNowLocal, deriveShift } from '@/utils/time';
 import { renderHeader } from '@/ui/header';
-import { renderTabs, activeTab } from '@/ui/tabs';
+import { renderTabs, activeTab, initTabs } from '@/ui/tabs';
 import { renderBoard } from '@/ui/board';
 import { renderSettings } from '@/ui/settings';
 import { renderHistoryTab } from '@/ui/historyTab';
@@ -33,7 +33,7 @@ document.addEventListener('history-saved', () =>
 export async function renderAll() {
   applyTheme();
   await renderHeader();
-  await renderTabs();
+  renderTabs();
   const root = document.getElementById('panel');
   if (!root) {
     console.error('Missing #panel element');
@@ -65,6 +65,7 @@ export async function manualHandoff() {
 }
 
 initState();
+initTabs();
 (async () => {
   const { dateISO, shift } = STATE;
   if (!(await Server.health())) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -95,6 +95,11 @@ header{display:grid;grid-template-columns:1fr auto auto;gap:var(--gap);align-ite
 .date-small{font-size:var(--f);color:var(--text-muted)}
 .actions{display:flex;gap:var(--gap);align-items:center}
 
+/* tab navigation */
+#tabs{display:flex;gap:var(--gap);margin-bottom:var(--gap)}
+#tabs [role="tab"]{background:var(--tab);border:1px solid var(--line);border-radius:8px;padding:6px 10px;cursor:pointer}
+#tabs [role="tab"].active{background:var(--accent);color:var(--text)}
+
 /* choose the variable-based sidebar width */
 .layout{display:grid;grid-template-columns:1fr var(--right-sidebar-w);gap:var(--gap)}
 .layout[data-testid="main-board"]{

--- a/src/ui/tabs.ts
+++ b/src/ui/tabs.ts
@@ -1,10 +1,46 @@
 import { renderAll } from '@/main';
 import { t } from '@/i18n/en';
 
-let active: string = 'Board';
+interface Tab {
+  id: string;
+  label: () => string;
+}
+
+const TABS: Tab[] = [
+  { id: 'Board', label: () => 'Board' },
+  { id: 'NextShift', label: () => t('nav.nextShift') },
+  { id: 'Settings', label: () => 'Settings' },
+  { id: 'History', label: () => t('nav.history') },
+];
+
+let active = 'Board';
 
 export function activeTab(): string {
   return active;
+}
+
+export function initTabs(): void {
+  const hash = location.hash.replace('#', '');
+  if (TABS.some((t) => t.id === hash)) {
+    active = hash;
+  }
+  history.replaceState({ tab: active }, '', `#${active}`);
+  window.addEventListener('popstate', (e) => {
+    const tab = (e.state && e.state.tab) || location.hash.replace('#', '');
+    if (TABS.some((t) => t.id === tab)) {
+      active = tab;
+      renderTabs();
+      renderAll();
+    }
+  });
+}
+
+function setActive(id: string): void {
+  if (active === id) return;
+  active = id;
+  history.pushState({ tab: id }, '', `#${id}`);
+  renderTabs();
+  renderAll();
 }
 
 export function renderTabs(): void {
@@ -14,17 +50,25 @@ export function renderTabs(): void {
     nav.id = 'tabs';
     document.body.insertBefore(nav, document.getElementById('panel'));
   }
-  nav.innerHTML = `
-    <button data-tab="Board">Board</button>
-    <button data-tab="NextShift">${t('nav.nextShift')}</button>
-    <button data-tab="Settings">Settings</button>
-    <button data-tab="History">${t('nav.history')}</button>
-  `;
+  nav.setAttribute('role', 'tablist');
+  nav.innerHTML = TABS.map((t) => `<button role="tab" data-tab="${t.id}">${t.label()}</button>`).join('');
+  nav.onkeydown = (e) => {
+    if (!(e.target instanceof HTMLButtonElement)) return;
+    let idx = TABS.findIndex((t) => t.id === e.target.dataset.tab);
+    if (e.key === 'ArrowRight') idx = (idx + 1) % TABS.length;
+    else if (e.key === 'ArrowLeft') idx = (idx - 1 + TABS.length) % TABS.length;
+    else return;
+    const next = TABS[idx].id;
+    setActive(next);
+    (nav!.querySelector(`button[data-tab="${next}"]`) as HTMLButtonElement)?.focus();
+    e.preventDefault();
+  };
   nav.querySelectorAll('button').forEach((btn) => {
-    btn.onclick = () => {
-      active = btn.getAttribute('data-tab') || 'Board';
-      renderAll();
-    };
+    const id = btn.getAttribute('data-tab') || 'Board';
+    btn.classList.toggle('active', id === active);
+    btn.setAttribute('aria-selected', id === active ? 'true' : 'false');
+    btn.tabIndex = id === active ? 0 : -1;
+    btn.onclick = () => setActive(id);
   });
   let panel = document.getElementById('panel');
   if (!panel) {


### PR DESCRIPTION
## Summary
- route active tab via URL hash and update history
- initialize tab from route and handle browser navigation
- render tab bar component with ARIA roles, keyboard navigation, and active styling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7834804b48327838a9f5a6eada43c