### PR TITLE
Fix offline save queue ordering

### DIFF
--- a/src/ui/board.ts
+++ b/src/ui/board.ts
@@ -54,16 +54,18 @@ let clockHandler: (() => void) | null = null;
 
 const offlineQueue: ActiveBoard[] = [];
 
-async function flushQueuedSaves(): Promise<void> {
+/** Attempt to flush queued board saves in order. */
+async function flushQueuedSaves(): Promise<Error | null> {
   while (offlineQueue.length) {
     const board = offlineQueue[0];
     try {
       await Server.save('active', board);
       offlineQueue.shift();
-    } catch {
-      break;
+    } catch (err) {
+      return err as Error;
     }
   }
+  return null;
 }
 
 window.addEventListener('online', () => {
@@ -211,13 +213,11 @@ export async function renderBoard(
 
     const flushServer = async () => {
       if (saveTimer) clearTimeout(saveTimer);
-      try {
-        await Server.save('active', active!);
-        void flushQueuedSaves();
-      } catch (err) {
+      offlineQueue.push(structuredClone(active!));
+      const err = await flushQueuedSaves();
+      if (err) {
         console.error('failed to save active board', err);
         showToast('Saving locally; server unreachable');
-        offlineQueue.push(structuredClone(active!));
       }
     };
 

--- a/tests/offlineQueue.spec.ts
+++ b/tests/offlineQueue.spec.ts
@@ -1,5 +1,5 @@
 /** @vitest-environment happy-dom */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 
 vi.mock('@/state', () => {
   const KS = {
@@ -68,6 +68,10 @@ import { openAssignDialog } from '@/ui/assignDialog';
 import { save as serverSave } from '@/server';
 
 describe('offline save queue', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
   it('flushes queued saves when back online', async () => {
     vi.useFakeTimers();
     const root = document.createElement('div');


### PR DESCRIPTION
## Summary
- Process queued board states before current save to avoid overwriting with stale snapshots
- Reset timers/mocks in offline queue test

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c782d2247c832792786300ca37674c