### PR TITLE
Preserve undo handling in assignments and restore Next Shift page

### DIFF
--- a/src/ui/board/assignments.ts
+++ b/src/ui/board/assignments.ts
@@ -1,3 +1,306 @@
+import * as State from '@/state';
+import type { ActiveBoard, Config, Slot, Staff } from '@/state';
+import { rosterStore } from '@/state/staff';
+import { labelFromId } from '@/utils/names';
+import { nurseTile } from '../nurseTile';
+import {
+  startBreak,
+  endBreak,
+  moveSlot,
+  upsertSlot,
+} from '@/slots';
+import { showBanner } from '@/ui/banner';
+import { openAssignDialog } from '@/ui/assignDialog';
+import { renderIncoming } from './incoming';
+
+type RoleFilter = 'all' | 'nurse' | 'tech';
+let roleFilter: RoleFilter = 'all';
+
+/** Default end time 12h after start. */
+export const defaultEnd = (start: string): string => {
+  const [h, m] = start.split(':').map(Number);
+  const end = (h * 60 + m + 12 * 60) % 1440;
+  const hh = String(Math.floor(end / 60)).padStart(2, '0');
+  const mm = String(end % 60).padStart(2, '0');
+  return `${hh}:${mm}`;
+};
+
+/** Create the Assignments panel. */
+export function createAssignmentsPanel(): HTMLElement {
+  const section = document.createElement('section');
+  section.className = 'panel';
+  section.innerHTML = `
+    <div class="panel-header">
+      <div>
+        <h3>Assignments</h3>
+        <p class="muted small">Place staff by zone and highlight empty slots.</p>
+      </div>
+      <div class="role-filter" role="group" aria-label="Filter assignments">
+        <button class="btn btn-pill" data-role-filter="all">All staff</button>
+        <button class="btn btn-pill" data-role-filter="nurse">RNs</button>
+        <button class="btn btn-pill" data-role-filter="tech">Techs</button>
+      </div>
+    </div>
+    <div id="zones" class="zones-grid"></div>
+  `;
+  return section;
+}
+
+/** Render all zone assignments. */
+export function renderAssignments(
+  active: ActiveBoard,
+  cfg: Config,
+  staff: Staff[],
+  save: () => void,
+  root: ParentNode,
+  beforeChange: () => void = () => {}
+): void {
+  const pctCont = root.querySelector('#pct-zones') as HTMLElement | null;
+  const cont = root.querySelector('#zones') as HTMLElement | null;
+  if (!pctCont || !cont) {
+    console.warn('Missing zones container');
+    return;
+  }
+  pctCont.innerHTML = '';
+  cont.innerHTML = '';
+  pctCont.style.minHeight = '40px';
+  cont.style.minHeight = '40px';
+  const roleButtons = Array.from(
+    (root as ParentNode).querySelectorAll<HTMLButtonElement>('[data-role-filter]')
+  );
+  roleButtons.forEach((btn) => {
+    const value = (btn.dataset.roleFilter as RoleFilter) || 'all';
+    btn.classList.toggle('active', value === roleFilter);
+    btn.onclick = () => {
+      roleFilter = value;
+      renderAssignments(active, cfg, staff, save, root, beforeChange);
+    };
+  });
+  const zones: any[] = cfg.zones || [];
+
+  if (zones.length === 0) {
+    cont.innerHTML = '<div class="muted">No zones configured. Add zones from Settings.</div>';
+    pctCont.innerHTML = '';
+    return;
+  }
+
+  zones.forEach((z: any, i: number) => {
+    const zName = z.name;
+    const section = document.createElement('section');
+    section.className = 'zone-card';
+    section.setAttribute('data-testid', 'zone-card');
+    section.draggable = true;
+    section.addEventListener('dragstart', (e) => {
+      const ev = e as DragEvent;
+      ev.dataTransfer?.setData('zone-index', String(i));
+    });
+
+    section.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+
+    section.addEventListener('drop', async (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const dt = (e as DragEvent).dataTransfer;
+      const nurseId = dt?.getData('incoming-id');
+      if (nurseId) {
+        const rawEnd = prompt('Shift end time (HH:MM)?')?.trim();
+        const end = rawEnd && /^\d{4}$/.test(rawEnd)
+          ? rawEnd.replace(/(\d{2})(\d{2})/, '$1:$2')
+          : rawEnd;
+        const slot: Slot = {
+          nurseId,
+          startHHMM: State.STATE.clockHHMM,
+          endTimeOverrideHHMM: end || defaultEnd(State.STATE.clockHHMM),
+        };
+        beforeChange();
+        const moved = upsertSlot(active, { zone: z.name }, slot);
+        if (moved) showBanner('Previous assignment cleared');
+        active.incoming = active.incoming.filter((i) => i.nurseId !== nurseId);
+        save();
+        renderIncoming(active, staff, save, beforeChange);
+        renderAssignments(active, cfg, staff, save, root, beforeChange);
+        return;
+      }
+
+      const zoneIdxStr = dt?.getData('zone-index');
+      if (!zoneIdxStr) return;
+      const fromIdx = Number(zoneIdxStr);
+      if (isNaN(fromIdx) || fromIdx === i) return;
+      beforeChange();
+      const [moved] = cfg.zones.splice(fromIdx, 1);
+      moved.pct = z.pct;
+      cfg.zones.splice(i, 0, moved);
+      await State.saveConfig({ zones: cfg.zones });
+      renderAssignments(active, cfg, staff, save, root, beforeChange);
+    });
+
+    const explicit = z.color || cfg.zoneColors?.[zName];
+    if (explicit) {
+      section.style.setProperty('--zone-color', explicit);
+    } else {
+      const zi = (i % 8) + 1;
+      section.style.setProperty('--zone-color', `var(--zone-bg-${zi})`);
+    }
+
+    const title = document.createElement('h2');
+    title.className = 'zone-card__title';
+    title.textContent = zName;
+    section.appendChild(title);
+
+    const editBtn = document.createElement('button');
+    editBtn.textContent = 'Zone settings';
+    editBtn.className = 'zone-card__edit';
+    editBtn.title = 'Rename or recolor this zone';
+    editBtn.setAttribute('aria-label', `Edit settings for ${zName}`);
+    editBtn.addEventListener('click', async () => {
+      const renamePrompt =
+        typeof window !== 'undefined' && typeof window.prompt === 'function'
+          ? window.prompt('Rename zone', z.name)
+          : null;
+      const val = renamePrompt?.trim();
+      if (val && val !== z.name) {
+        if (cfg.zones.some((zz) => zz.name === val)) {
+          alert('A zone with that name already exists.');
+          return;
+        }
+        beforeChange();
+        const idx = cfg.zones.findIndex((zz) => zz.name === z.name);
+        cfg.zones[idx].name = val;
+        if (cfg.zoneColors && cfg.zoneColors[z.name]) {
+          cfg.zoneColors[val] = cfg.zoneColors[z.name];
+          delete cfg.zoneColors[z.name];
+        }
+        active.zones[val] = active.zones[z.name] || [];
+        delete active.zones[z.name];
+        await State.saveConfig({ zones: cfg.zones, zoneColors: cfg.zoneColors });
+          document.dispatchEvent(new Event('config-changed'));
+          await save();
+          renderAssignments(active, cfg, staff, save, root, beforeChange);
+      }
+    });
+    section.appendChild(editBtn);
+
+    const body = document.createElement('div');
+    body.className = 'zone-card__body';
+
+    (active.zones[zName] || []).forEach((s: Slot, idx: number) => {
+      let st = staff.find((n) => n.id === s.nurseId);
+      if (!st) {
+        console.warn('Unknown staffId', s.nurseId);
+        st = {
+          id: s.nurseId,
+          name: s.nurseId,
+          role: 'nurse',
+          type: 'other',
+        } as Staff;
+      }
+
+      const row = document.createElement('div');
+      row.className = 'nurse-row';
+      const isHidden =
+        roleFilter !== 'all' && (st.role || 'nurse').toLowerCase() !== roleFilter;
+      row.classList.toggle('nurse-row--hidden', isHidden);
+
+      const tileWrapper = document.createElement('div');
+      tileWrapper.innerHTML = nurseTile(s, {
+        id: st.id,
+        name: st.name,
+        role: st.role || 'nurse',
+        type: st.type || 'other',
+      } as Staff);
+      const tile = tileWrapper.firstElementChild as HTMLElement;
+      row.appendChild(tile);
+      if (s.assignedTs && Date.now() - s.assignedTs < 15 * 60 * 1000) {
+        tile.classList.add('recent-assignment');
+        const remaining = 15 * 60 * 1000 - (Date.now() - s.assignedTs);
+        setTimeout(() => tile.classList.remove('recent-assignment'), remaining);
+      }
+
+      const btn = document.createElement('button');
+      btn.textContent = 'Manage';
+      btn.className = 'btn';
+      btn.addEventListener('click', () =>
+        manageSlot(
+          s,
+          st!,
+          staff,
+          save,
+          () => renderAssignments(active, cfg, staff, save, root, beforeChange),
+          z.name,
+          idx,
+          active,
+          cfg,
+          beforeChange
+        )
+      );
+
+      row.appendChild(btn);
+      body.appendChild(row);
+    });
+
+    const hasSlots = (active.zones[zName] || []).length > 0;
+    if (!hasSlots) {
+      const empty = document.createElement('div');
+      empty.className = 'zone-card__empty';
+      empty.textContent = 'No staff assigned';
+      body.appendChild(empty);
+      section.classList.add('zone-card--empty');
+    } else {
+      section.classList.remove('zone-card--empty');
+    }
+    const addBtn = document.createElement('button');
+    addBtn.textContent = '+ Add staff';
+    addBtn.className = hasSlots
+      ? 'zone-card__add zone-card__add--small'
+      : 'zone-card__add zone-card__add--large';
+    addBtn.title = 'Open the staff picker';
+    addBtn.setAttribute('aria-label', `Add staff to ${zName}`);
+    addBtn.addEventListener('click', () => {
+      openAssignDialog(staff, (id) => {
+        beforeChange();
+        const slot: Slot = {
+          nurseId: id,
+          startHHMM: State.STATE.clockHHMM,
+          endTimeOverrideHHMM: defaultEnd(State.STATE.clockHHMM),
+        };
+        const moved = upsertSlot(active, { zone: z.name }, slot);
+        if (moved) showBanner('Previous assignment cleared');
+        save();
+        renderAssignments(active, cfg, staff, save, root, beforeChange);
+      });
+    });
+    if (hasSlots) {
+      section.appendChild(addBtn);
+    } else {
+      body.appendChild(addBtn);
+    }
+
+    section.appendChild(body);
+    (z.pct ? pctCont : cont).appendChild(section);
+  });
+
+  const enableDrop = (container: HTMLElement, pct: boolean) => {
+    container.addEventListener('dragover', (e) => e.preventDefault());
+    container.addEventListener('drop', async (e) => {
+      e.preventDefault();
+      const zoneIdxStr = (e as DragEvent).dataTransfer?.getData('zone-index');
+      if (!zoneIdxStr) return;
+      const idx = Number(zoneIdxStr);
+      if (isNaN(idx)) return;
+      beforeChange();
+      cfg.zones[idx].pct = pct;
+      await State.saveConfig({ zones: cfg.zones });
+      renderAssignments(active, cfg, staff, save, root, beforeChange);
+    });
+  };
+
+  enableDrop(pctCont, true);
+  enableDrop(cont, false);
+}
+
 function manageSlot(
   slot: Slot,
   st: Staff,
@@ -61,14 +364,9 @@ function manageSlot(
 
   overlay.querySelector('#mg-save')!.addEventListener('click', async () => {
     beforeChange();
-
-    // RF value: store number if present, otherwise remove rf
-    const rfVal = (overlay.querySelector('#mg-rf') as HTMLInputElement).value.trim();
-    if (rfVal) {
-      st.rf = Number(rfVal);
-    } else {
-      delete st.rf;
-    }
+      const rfVal = (overlay.querySelector('#mg-rf') as HTMLInputElement).value.trim();
+      if (rfVal) st.rf = Number(rfVal);
+      else delete st.rf;
 
     const studVal = (overlay.querySelector('#mg-student') as HTMLInputElement).value.trim();
     slot.student = studVal ? studVal : undefined;
@@ -89,10 +387,9 @@ function manageSlot(
       if (moved) showBanner('Previous assignment cleared');
     }
 
-    if (typeof rosterStore.save === 'function') {
-      await rosterStore.save(staffList);
-    }
-
+      if (typeof rosterStore.save === 'function') {
+        await rosterStore.save(staffList);
+      }
     save();
     overlay.remove();
     rerender();

--- a/src/ui/nextShift/NextShiftPage.ts
+++ b/src/ui/nextShift/NextShiftPage.ts
@@ -1,26 +1,327 @@
-  root.querySelectorAll('.zone-drop').forEach((el) => {
-    const target = el as HTMLElement;
+import './nextShift.css';
+import { getConfig, loadConfig } from '@/state/config';
+import { seedZonesIfNeeded } from '@/seed';
+import {
+  buildEmptyDraft,
+  loadNextDraft,
+  saveNextDraft,
+  publishNextDraft,
+  type DraftShift,
+} from '@/state/nextShift';
+import { rosterStore, type Staff } from '@/state/staff';
+import { type Slot } from '@/slots';
+import { deriveShift } from '@/utils/time';
+import { showToast } from '@/ui/banner';
 
-    target.addEventListener('dragover', (e: DragEvent) => e.preventDefault());
+const pad = (n: number): string => n.toString().padStart(2, '0');
+const fmtLocal = (d: Date): string =>
+  `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours(),
+  )}:${pad(d.getMinutes())}`;
 
-    target.addEventListener('drop', (e: DragEvent) => {
-      e.preventDefault();
-      const id = e.dataTransfer?.getData('text/plain');
-      if (!id || !draft) return;
+function nextShiftStartISO(now = new Date()): string {
+  const schedule = [7, 11, 15, 19];
+  const minutes = now.getHours() * 60 + now.getMinutes();
+  for (const h of schedule) {
+    if (minutes < h * 60) {
+      const d = new Date(now);
+      d.setHours(h, 0, 0, 0);
+      return fmtLocal(d);
+    }
+  }
+  const d = new Date(now);
+  d.setDate(d.getDate() + 1);
+  d.setHours(7, 0, 0, 0);
+  return fmtLocal(d);
+}
 
-      pushUndo();
+/** Render a simple Next Shift planning page with save and publish controls. */
+export async function renderNextShiftPage(root: HTMLElement): Promise<void> {
+  await loadConfig();
+  await seedZonesIfNeeded();
+  const cfg = getConfig();
+  await rosterStore.load();
+  const staff = rosterStore.active();
+  let draft: DraftShift | null = await loadNextDraft();
+  let undoStack: DraftShift[] = [];
+  if (!draft) {
+    const startISO = nextShiftStartISO();
+    const dateISO = startISO.slice(0, 10);
+    const hhmm = startISO.slice(11, 16);
+    draft = buildEmptyDraft(dateISO, deriveShift(hhmm), cfg.zones || []);
+    draft.publishAtISO = startISO;
+    const end = new Date(startISO);
+    end.setHours(end.getHours() + 12);
+    draft.endAtISO = fmtLocal(end);
+  } else {
+    if (!draft.publishAtISO) {
+      const startISO = nextShiftStartISO();
+      draft.publishAtISO = startISO;
+      draft.dateISO = startISO.slice(0, 10);
+      draft.shift = deriveShift(startISO.slice(11, 16));
+    }
+    if (!draft.endAtISO) {
+      const startISO = draft.publishAtISO || nextShiftStartISO();
+      const end = new Date(startISO);
+      end.setHours(end.getHours() + 12);
+      draft.endAtISO = fmtLocal(end);
+    }
+  }
 
-      const s = staff.find((st) => st.id === id);
-      target.textContent = s?.name || id;
-      target.dataset.nurseId = id;
-      target.classList.remove('empty');
+  const zoneRows = (cfg.zones || [])
+    .map((z) => {
+      const slot = draft?.zones?.[z.name]?.[0];
+      const name = slot
+        ? staff.find((s) => s.id === slot.nurseId)?.name || slot.nurseId
+        : '';
+      return `<tr><td>${z.name}</td><td class="zone-cell"><div id="zone-${z.id}" class="zone-drop" data-zone="${z.name}" ${
+        slot ? `data-nurse-id="${slot.nurseId}"` : ''
+      }>${name}</div><button class="btn zone-clear" data-zone-id="${z.id}">Clear</button></td></tr>`;
+    })
+    .join('');
 
-      const zoneKey = target.dataset.zone || '';
-      if (!draft.zones[zoneKey]) {
-        draft.zones[zoneKey] = [];
+  root.innerHTML = `
+    <section class="panel next-shift" data-testid="next-shift">
+      <h3>Next Shift</h3>
+      <div class="next-shift-body">
+        <div class="staff-panel">
+          <input id="next-search" class="input" placeholder="Search staff">
+          <div class="assign-cols">
+            <div id="next-nurses" class="assign-col"></div>
+            <div id="next-techs" class="assign-col"></div>
+          </div>
+        </div>
+        <div class="assign-panel">
+          <table class="assignments">
+            <thead><tr><th>Zone</th><th>Nurse</th></tr></thead>
+            <tbody>
+              ${zoneRows}
+            </tbody>
+          </table>
+          <div class="actions">
+            <label>Go Live <input type="datetime-local" id="next-go-live" value="${
+              draft.publishAtISO || ''
+            }"></label>
+            <label>End Time <input type="datetime-local" id="next-end" value="${
+              draft.endAtISO || ''
+            }"></label>
+            <button id="next-undo" class="btn" disabled>Undo last change</button>
+            <button id="next-save" class="btn">Save Draft</button>
+            <button id="next-publish" class="btn">Publish</button>
+          </div>
+        </div>
+      </div>
+    </section>
+  `;
+
+  const nurseCol = document.getElementById('next-nurses') as HTMLElement;
+  const techCol = document.getElementById('next-techs') as HTMLElement;
+  const searchInput = document.getElementById('next-search') as HTMLInputElement;
+  const goLiveInput = document.getElementById('next-go-live') as HTMLInputElement;
+  const endInput = document.getElementById('next-end') as HTMLInputElement;
+  const undoBtn = document.getElementById('next-undo') as HTMLButtonElement;
+
+  let selected: string | null = null;
+  let publishTimer: number | undefined;
+
+  const updateUndo = () => {
+    undoBtn.disabled = undoStack.length === 0;
+  };
+
+  const pushUndo = () => {
+    if (!draft) return;
+    undoStack.push(structuredClone(draft));
+    updateUndo();
+  };
+
+  const applyDraftToUI = (next: DraftShift): void => {
+    draft = structuredClone(next);
+    goLiveInput.value = draft.publishAtISO || '';
+    endInput.value = draft.endAtISO || '';
+    for (const z of cfg.zones || []) {
+      const el = document.getElementById(`zone-${z.id}`) as HTMLElement | null;
+      const slot = draft.zones?.[z.name]?.[0];
+      if (!el) continue;
+      const name = slot
+        ? staff.find((s) => s.id === slot.nurseId)?.name || slot.nurseId
+        : '';
+      el.textContent = name;
+      if (slot?.nurseId) {
+        el.dataset.nurseId = slot.nurseId;
+      } else {
+        delete el.dataset.nurseId;
       }
-      draft.zones[zoneKey] = [{ nurseId: id }];
+      el.classList.toggle('empty', !slot);
+    }
+    updateUndo();
+  };
 
+  applyDraftToUI(draft);
+
+  undoBtn.addEventListener('click', () => {
+    const previous = undoStack.pop();
+    updateUndo();
+    if (!previous) return;
+    applyDraftToUI(previous);
+    showToast('Reverted last draft change');
+  });
+
+  function renderStaff(filter = ''): void {
+    const norm = filter.toLowerCase();
+    const nurses = staff.filter(
+      (s) =>
+        s.role === 'nurse' &&
+        (!filter || (s.name || s.id).toLowerCase().includes(norm))
+    );
+    const techs = staff.filter(
+      (s) =>
+        s.role === 'tech' &&
+        (!filter || (s.name || s.id).toLowerCase().includes(norm))
+    );
+    nurseCol.innerHTML = nurses
+      .map(
+        (s) =>
+          `<div class="assign-item${selected === s.id ? ' selected' : ''}" draggable="true" data-id="${s.id}">${
+            s.name || s.id
+          }</div>`
+      )
+      .join('');
+    techCol.innerHTML = techs
+      .map(
+        (s) =>
+          `<div class="assign-item${selected === s.id ? ' selected' : ''}" draggable="true" data-id="${s.id}">${
+            s.name || s.id
+          }</div>`
+      )
+      .join('');
+    root.querySelectorAll('.assign-item').forEach((el) => {
+      const id = (el as HTMLElement).dataset.id!;
+      el.addEventListener('click', () => {
+        selected = id;
+        root.querySelectorAll('.assign-item').forEach((item) => {
+          item.classList.toggle('selected', (item as HTMLElement).dataset.id === id);
+        });
+      });
+      (el as HTMLElement).addEventListener('dragstart', (ev: DragEvent) => {
+        ev.dataTransfer?.setData('text/plain', id);
+      });
+    });
+  }
+
+  renderStaff();
+  searchInput.addEventListener('input', () => renderStaff(searchInput.value));
+
+    root.querySelectorAll('.zone-drop').forEach((el) => {
+      (el as HTMLElement).addEventListener('dragover', (e: DragEvent) => e.preventDefault());
+      (el as HTMLElement).addEventListener('drop', (e: DragEvent) => {
+        e.preventDefault();
+        const id = e.dataTransfer?.getData('text/plain');
+        if (id && draft) {
+          pushUndo();
+          const s = staff.find((st) => st.id === id);
+          const target = el as HTMLElement;
+          target.textContent = s?.name || id;
+          target.dataset.nurseId = id;
+          target.classList.remove('empty');
+          if (!draft.zones[`${target.dataset.zone}`]) {
+            draft.zones[`${target.dataset.zone}`] = [];
+          }
+          draft.zones[target.dataset.zone || ''] = [{ nurseId: id }];
+          updateUndo();
+        }
+      });
+    });
+
+  root.querySelectorAll('.zone-clear').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      pushUndo();
+      const id = (btn as HTMLElement).dataset.zoneId;
+      const zone = document.getElementById(`zone-${id}`) as HTMLElement | null;
+      if (zone) {
+        zone.textContent = '';
+        delete zone.dataset.nurseId;
+        zone.classList.add('empty');
+      }
+      const zoneDef = (cfg.zones || []).find((z) => String(z.id) === id);
+      if (zoneDef && draft?.zones) {
+        draft.zones[zoneDef.name] = [];
+      }
       updateUndo();
     });
   });
+
+  function gatherDraft(): DraftShift {
+    const publishAt = goLiveInput.value || '';
+    let endAt = endInput.value || '';
+    if (!endAt && publishAt) {
+      const d = new Date(publishAt);
+      d.setHours(d.getHours() + 12);
+      endAt = fmtLocal(d);
+    }
+    const dateISO = publishAt ? publishAt.slice(0, 10) : draft!.dateISO;
+    const hhmm = publishAt ? publishAt.slice(11, 16) : '07:00';
+    const shift = publishAt ? deriveShift(hhmm) : draft!.shift;
+    const zones: Record<string, Slot[]> = {};
+    for (const z of cfg.zones || []) {
+      const el = document.getElementById(`zone-${z.id}`) as HTMLElement | null;
+      const id = el?.dataset.nurseId;
+      zones[z.name] = id ? [{ nurseId: id }] : [];
+    }
+    return {
+      ...draft!,
+      dateISO,
+      shift,
+      charge: undefined,
+      triage: undefined,
+      admin: undefined,
+      zones,
+      publishAtISO: publishAt || undefined,
+      endAtISO: endAt || undefined,
+    };
+  }
+
+  function schedulePublish(): void {
+    if (publishTimer) clearTimeout(publishTimer);
+    if (!draft?.publishAtISO) return;
+    const delay = new Date(draft.publishAtISO).getTime() - Date.now();
+    if (delay <= 0) {
+      void publishNextDraft();
+    } else {
+      publishTimer = window.setTimeout(() => {
+        void publishNextDraft();
+      }, delay);
+    }
+  }
+
+  document.getElementById('next-save')?.addEventListener('click', async () => {
+    pushUndo();
+    draft = gatherDraft();
+    await saveNextDraft(draft);
+    applyDraftToUI(draft);
+    schedulePublish();
+    if (draft.publishAtISO) {
+      const start = draft.publishAtISO.slice(11, 16);
+      const when = new Date(draft.publishAtISO).toLocaleString();
+      showToast(`Shift saved; will publish at ${when} (start ${start})`);
+    } else {
+      showToast('Shift saved');
+    }
+  });
+
+  document
+    .getElementById('next-publish')
+    ?.addEventListener('click', async () => {
+      pushUndo();
+      draft = gatherDraft();
+      await saveNextDraft(draft);
+      applyDraftToUI(draft);
+      if (publishTimer) clearTimeout(publishTimer);
+      try {
+        await publishNextDraft();
+      } catch (err) {
+        console.error(err);
+      }
+    });
+
+  schedulePublish();
+}


### PR DESCRIPTION
## Summary
- pass the existing beforeChange undo callback when rerendering assignments after adding staff
- ensure zone rename rerenders keep undo wiring intact
- restore the Next Shift page implementation so planning UI and tests load correctly

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69299a871e748327a4b3613ded3339d0)